### PR TITLE
Restore experimental LLM translation API

### DIFF
--- a/alarino_backend/main/app.py
+++ b/alarino_backend/main/app.py
@@ -6,7 +6,14 @@ from flask import request, jsonify
 
 from main import app, db, _daily_word_cache, logger
 from main.languages import Language
-from main.translation_service import translate, get_word_of_the_day, APIResponse, get_random_proverb, bulk_upload_words
+from main.translation_service import (
+    translate,
+    translate_llm,
+    get_word_of_the_day,
+    APIResponse,
+    get_random_proverb,
+    bulk_upload_words,
+)
 
 
 def admin_required(f):
@@ -28,40 +35,48 @@ def admin_required(f):
     return decorated_function
 
 
+def require_translation_params(f):
+    @wraps(f)
+    def decorated_function(*args, **kwargs):
+        data: Dict[str, Any] | None = request.get_json(silent=True)
+        if not data or not all(k in data for k in ['text', 'source_lang', 'target_lang']):
+            return APIResponse.error("Invalid request body.", 400).as_response()
+
+        try:
+            kwargs['text'] = data['text']
+            kwargs['source_language'] = Language(data['source_lang'])
+            kwargs['target_language'] = Language(data['target_lang'])
+        except ValueError:
+            return APIResponse.error("Unsupported language.", 400).as_response()
+
+        return f(*args, **kwargs)
+
+    return decorated_function
+
+
 @app.route('/api/translate', methods=['POST'])
-def get_translation():
-    """
-    Receives JSON data with:
-    {
-      "text": "Hello",
-      "source_lang": "en",
-      "target_lang": "yo"
-    }
-    and returns a JSON response with:
-    of type APIResponse, status
-    """
-    # Extract JSON payload
-    data: Dict[str, Any] | None = request.get_json()
-    logger.info("got translation request: \t%s", data)
+@require_translation_params
+def get_translation(text: str, source_language: Language, target_language: Language):
+    logger.info("got translation request: \t%s", text)
 
-    # Validate the required fields
-    if not data or not all(k in data for k in ['text', 'source_lang', 'target_lang']):
-        return APIResponse.error("Invalid request body.", 400).as_response()
-
-    try:
-        text: str = data['text']
-        source_language: Language = Language(data['source_lang'])
-        target_language: Language = Language(data['target_lang'])
-    except ValueError:
-        return APIResponse.error("Unsupported language.", 400).as_response()
-
-    # Call translation
     response: Dict[str, Any]
     status: int
     response, status = translate(
         db, text, source_language, target_language,
         request.remote_addr, request.headers.get("User-Agent", "unknown")
     )
+
+    return jsonify(response), status
+
+
+@app.route('/api/translate/llm', methods=['POST'])
+@require_translation_params
+def get_llm_translation(text: str, source_language: Language, target_language: Language):
+    logger.info("got llm translation request: \t%s", text)
+
+    response: Dict[str, Any]
+    status: int
+    response, status = translate_llm(text, source_language, target_language)
 
     return jsonify(response), status
 

--- a/alarino_backend/tests/test_app.py
+++ b/alarino_backend/tests/test_app.py
@@ -1,23 +1,27 @@
-import pytest
 import os
-from main import app
-from main.languages import Language
-# import to get the route handler
-from main.app import get_translation, admin_bulk_upload
-from main.db_models import Word, Translation
+import importlib
 
-#todo: make tests independent of database access
+import main.translation_service as translation_service
+import pytest
+from main import app as flask_app
+from main.languages import Language
+
+importlib.import_module("main.app")
+
+
+# todo: make tests independent of database access
+
 
 @pytest.fixture
 def client():
     """
     Creates a test client for our Flask app.
     """
-    app.config['TESTING'] = True
+    flask_app.config['TESTING'] = True
     print("rules:")
-    print([str(rule) for rule in app.url_map.iter_rules()])
+    print([str(rule) for rule in flask_app.url_map.iter_rules()])
     print("rules?")
-    with app.test_client() as client:
+    with flask_app.test_client() as client:
         yield client
 
 
@@ -27,10 +31,10 @@ def test_translate_no_data(client):
     We expect a 400 status code and an error message.
     """
     response = client.post('/api/translate')
-    assert response.status_code == 415
-    assert not response.is_json
-    # data = response.get_json()
-    # assert data.get("error") == "Invalid request body."
+    assert response.status_code == 400
+    assert response.is_json
+    data = response.get_json()
+    assert data.get("message") == "Invalid request body."
 
 
 def test_translate_missing_fields(client):
@@ -38,7 +42,6 @@ def test_translate_missing_fields(client):
     Test the /api/translate endpoint with missing fields in JSON data.
     We expect a 400 status code and an error message.
     """
-    # Only provide "text" field, missing "source_language" and "target_language"
     payload = {"text": "Hello"}
     response = client.post('/api/translate', json=payload)
 
@@ -63,9 +66,6 @@ def test_translate_success(client):
     assert response.status_code == 200
     assert response.is_json
     data = response.get_json()
-
-    # We can do a simple assertion since our translator is a stub.
-    # In a real scenario, you'd verify actual translations or structure of the data.
     assert "translation" in data.get("data")
 
 
@@ -82,6 +82,90 @@ def test_translate_custom_text(client):
     response = client.post('/api/translate', json=payload)
     assert response.status_code == 404
 
+
+def test_translate_llm_missing_fields(client):
+    payload = {"text": "Hello"}
+    response = client.post('/api/translate/llm', json=payload)
+
+    assert response.status_code == 400
+    assert response.is_json
+    data = response.get_json()
+    assert data.get("message") == "Invalid request body."
+
+
+def test_translate_llm_unsupported_language(client):
+    payload = {
+        "text": "Hello",
+        "source_lang": "xx",
+        "target_lang": Language.YORUBA.value
+    }
+    response = client.post('/api/translate/llm', json=payload)
+
+    assert response.status_code == 400
+    assert response.is_json
+    data = response.get_json()
+    assert data.get("message") == "Unsupported language."
+
+
+def test_translate_llm_not_configured(client, monkeypatch):
+    monkeypatch.setattr(translation_service, "get_llm_service", lambda: None)
+
+    payload = {
+        "text": "hello",
+        "source_lang": Language.ENGLISH.value,
+        "target_lang": Language.YORUBA.value
+    }
+    response = client.post('/api/translate/llm', json=payload)
+
+    assert response.status_code == 500
+    assert response.is_json
+    data = response.get_json()
+    assert data.get("message") == "LLM service not configured."
+
+
+def test_translate_llm_success(client, monkeypatch):
+    class StubLLMService:
+        def get_translation(self, text, source_lang, target_lang):
+            assert text == "hello"
+            assert source_lang == Language.ENGLISH.value
+            assert target_lang == Language.YORUBA.value
+            return ["bawo"]
+
+    monkeypatch.setattr(translation_service, "get_llm_service", lambda: StubLLMService())
+
+    payload = {
+        "text": "hello",
+        "source_lang": Language.ENGLISH.value,
+        "target_lang": Language.YORUBA.value
+    }
+    response = client.post('/api/translate/llm', json=payload)
+
+    assert response.status_code == 200
+    assert response.is_json
+    data = response.get_json().get("data")
+    assert data["source_word"] == "hello"
+    assert data["translation"] == ["bawo"]
+    assert data["to_language"] == Language.YORUBA.value
+
+
+def test_translate_llm_not_found(client, monkeypatch):
+    class StubLLMService:
+        def get_translation(self, text, source_lang, target_lang):
+            return []
+
+    monkeypatch.setattr(translation_service, "get_llm_service", lambda: StubLLMService())
+
+    payload = {
+        "text": "hello",
+        "source_lang": Language.ENGLISH.value,
+        "target_lang": Language.YORUBA.value
+    }
+    response = client.post('/api/translate/llm', json=payload)
+
+    assert response.status_code == 404
+    assert response.is_json
+    data = response.get_json()
+    assert data.get("message") == "Translation not found."
 
 
 def test_admin_bulk_upload_unauthorized(client):
@@ -153,8 +237,6 @@ def test_admin_bulk_upload_dry_run_success(client):
 #     assert data['dry_run'] is False
 #     assert len(data['successful_pairs']) == 2
 #     assert len(data['failed_pairs']) == 0
-#     assert Word.query.count() == 4
-#     assert Translation.query.count() == 2
 
 
 def test_admin_bulk_upload_with_invalid_data(client):

--- a/frontend/components/home-page.test.tsx
+++ b/frontend/components/home-page.test.tsx
@@ -18,8 +18,34 @@ function jsonResponse(payload: unknown, status = 200) {
   );
 }
 
-beforeEach(() => {
-  vi.spyOn(global, "fetch").mockImplementation((input) => {
+function createFetchMock({
+  dbStatus = 200,
+  dbData = {
+    source_word: "hello",
+    translation: ["bawo"],
+    to_language: "yo"
+  },
+  experimentalStatus = 200,
+  experimentalData = {
+    source_word: "hello",
+    translation: ["ẹ káàbọ̀"],
+    to_language: "yo"
+  }
+}: {
+  dbStatus?: number;
+  dbData?: {
+    source_word: string;
+    translation: string[];
+    to_language: string;
+  } | null;
+  experimentalStatus?: number;
+  experimentalData?: {
+    source_word: string;
+    translation: string[];
+    to_language: string;
+  } | null;
+} = {}) {
+  return vi.spyOn(global, "fetch").mockImplementation((input) => {
     const url = String(input);
 
     if (url.includes("/daily-word")) {
@@ -46,22 +72,33 @@ beforeEach(() => {
       });
     }
 
+    if (url.includes("/translate/llm")) {
+      return jsonResponse(
+        {
+          success: experimentalStatus >= 200 && experimentalStatus < 300,
+          status: experimentalStatus,
+          message: experimentalStatus >= 200 && experimentalStatus < 300 ? "ok" : "missing",
+          data: experimentalData
+        },
+        experimentalStatus
+      );
+    }
+
     if (url.includes("/translate")) {
-      return jsonResponse({
-        success: true,
-        status: 200,
-        message: "ok",
-        data: {
-          source_word: "hello",
-          translation: ["bawo"],
-          to_language: "yo"
-        }
-      });
+      return jsonResponse(
+        {
+          success: dbStatus >= 200 && dbStatus < 300,
+          status: dbStatus,
+          message: dbStatus >= 200 && dbStatus < 300 ? "ok" : "missing",
+          data: dbData
+        },
+        dbStatus
+      );
     }
 
     return jsonResponse({ success: false, status: 404, message: "not found", data: null }, 404);
   });
-});
+}
 
 const replaceStateSpy = vi.fn();
 
@@ -75,7 +112,9 @@ afterEach(() => {
 });
 
 describe("HomePage", () => {
-  it("submits translations and updates the word route", async () => {
+  it("submits translations, renders experimental results, and updates the word route", async () => {
+    createFetchMock();
+
     const user = userEvent.setup();
     render(<HomePage />);
 
@@ -85,11 +124,78 @@ describe("HomePage", () => {
     await waitFor(() => {
       expect(screen.getByText("hello")).toBeInTheDocument();
       expect(screen.getByText("bawo")).toBeInTheDocument();
+      expect(screen.getByText("Experimental")).toBeInTheDocument();
+      expect(screen.getByText("ẹ káàbọ̀")).toBeInTheDocument();
       expect(replaceStateSpy).toHaveBeenCalledWith(null, "", "/word/hello");
     });
   });
 
+  it("renders only the primary translation when the experimental call fails", async () => {
+    createFetchMock({
+      experimentalStatus: 500,
+      experimentalData: null
+    });
+
+    const user = userEvent.setup();
+    render(<HomePage />);
+
+    await user.type(screen.getByLabelText(/enter an english word/i), "hello");
+    await user.click(screen.getByRole("button", { name: "Translate" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("bawo")).toBeInTheDocument();
+      expect(screen.queryByText("Experimental")).not.toBeInTheDocument();
+    });
+  });
+
+  it("renders the experimental translation when the dictionary lookup fails", async () => {
+    createFetchMock({
+      dbStatus: 404,
+      dbData: null,
+      experimentalData: {
+        source_word: "xylophone",
+        translation: ["sáfẹ́ẹ̀lì"],
+        to_language: "yo"
+      }
+    });
+
+    const user = userEvent.setup();
+    render(<HomePage />);
+
+    await user.type(screen.getByLabelText(/enter an english word/i), "xylophone");
+    await user.click(screen.getByRole("button", { name: "Translate" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("xylophone")).toBeInTheDocument();
+      expect(screen.getByText("Experimental")).toBeInTheDocument();
+      expect(screen.getByText("sáfẹ́ẹ̀lì")).toBeInTheDocument();
+      expect(screen.getByText("Dictionary result not found. Showing experimental translation.")).toBeInTheDocument();
+    });
+  });
+
+  it("shows the existing error copy when both translation calls fail", async () => {
+    createFetchMock({
+      dbStatus: 404,
+      dbData: null,
+      experimentalStatus: 404,
+      experimentalData: null
+    });
+
+    const user = userEvent.setup();
+    render(<HomePage />);
+
+    await user.type(screen.getByLabelText(/enter an english word/i), "unknown");
+    await user.click(screen.getByRole("button", { name: "Translate" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("We're still learning! Please try another translation.")).toBeInTheDocument();
+      expect(screen.queryByText("Experimental")).not.toBeInTheDocument();
+    });
+  });
+
   it("toggles word-of-day translation and opens/closes contribution modal", async () => {
+    createFetchMock();
+
     const user = userEvent.setup();
     render(<HomePage />);
 

--- a/frontend/components/home/translator-card.tsx
+++ b/frontend/components/home/translator-card.tsx
@@ -24,6 +24,10 @@ export function TranslatorCard({
     () => translationState.translation.map((line) => line.trim()).filter(Boolean),
     [translationState.translation]
   );
+  const experimentalMarkup = useMemo(
+    () => translationState.experimentalTranslation.map((line) => line.trim()).filter(Boolean),
+    [translationState.experimentalTranslation]
+  );
 
   return (
     <section
@@ -110,6 +114,18 @@ export function TranslatorCard({
                     <p key={`${line}-${index}`}>{line}</p>
                   ))}
                 </div>
+                {experimentalMarkup.length > 0 ? (
+                  <section className="mt-5 rounded-xl border border-brand-brown/[0.08] bg-white/75 px-4 py-3">
+                    <p className="text-[0.7rem] font-bold uppercase tracking-[0.15em] text-brand-brown/60">
+                      Experimental
+                    </p>
+                    <div className="mt-2 space-y-1 text-lg font-semibold text-brand-brown">
+                      {experimentalMarkup.map((line, index) => (
+                        <p key={`${line}-experimental-${index}`}>{line}</p>
+                      ))}
+                    </div>
+                  </section>
+                ) : null}
                 {translationState.description ? (
                   <p className="mt-3 text-sm text-brand-ink/60">{translationState.description}</p>
                 ) : null}

--- a/frontend/components/home/use-home-page-state.ts
+++ b/frontend/components/home/use-home-page-state.ts
@@ -3,13 +3,19 @@
 import { useCallback, useEffect, useState } from "react";
 
 import { DEFAULT_TRANSLATION_LINES, DEFAULT_TRANSLATION_WORD } from "@/lib/constants";
-import { fetchDailyWord, fetchRandomProverb, translateEnglishWord } from "@/lib/api";
+import {
+  fetchDailyWord,
+  fetchRandomProverb,
+  translateEnglishWord,
+  translateEnglishWordExperimental
+} from "@/lib/api";
 
 export type ModalType = "add-word" | "feedback" | null;
 
 export type TranslationViewState = {
   word: string;
   translation: string[];
+  experimentalTranslation: string[];
   description: string;
   loading: boolean;
   error: boolean;
@@ -28,6 +34,7 @@ export type ProverbState = {
 const EMPTY_TRANSLATION_STATE: TranslationViewState = {
   word: DEFAULT_TRANSLATION_WORD,
   translation: DEFAULT_TRANSLATION_LINES,
+  experimentalTranslation: [],
   description: "",
   loading: false,
   error: false
@@ -67,19 +74,30 @@ export function useHomePageState({ initialWord, onTranslatedWord }: UseHomePageS
       setTranslationState((previous) => ({
         word: normalizedInput,
         translation: previous.word === normalizedInput ? previous.translation : [],
+        experimentalTranslation: [],
         description: "",
         loading: true,
         error: false
       }));
 
-      const response = await translateEnglishWord(normalizedInput);
+      const [dbResult, experimentalResult] = await Promise.allSettled([
+        translateEnglishWord(normalizedInput),
+        translateEnglishWordExperimental(normalizedInput)
+      ]);
 
-      if (response.success && response.data) {
+      const response = dbResult.status === "fulfilled" ? dbResult.value : null;
+      const experimentalResponse = experimentalResult.status === "fulfilled" ? experimentalResult.value : null;
+      const experimentalTranslation = experimentalResponse?.success && experimentalResponse.data
+        ? experimentalResponse.data.translation
+        : [];
+
+      if (response?.success && response.data) {
         const translatedWord = response.data.source_word.toLowerCase();
 
         setTranslationState({
           word: translatedWord,
           translation: response.data.translation,
+          experimentalTranslation,
           description: "",
           loading: false,
           error: false
@@ -89,13 +107,26 @@ export function useHomePageState({ initialWord, onTranslatedWord }: UseHomePageS
         return;
       }
 
-      const errorMessage = response.status === 404
+      if (experimentalTranslation.length > 0) {
+        setTranslationState({
+          word: normalizedInput,
+          translation: [],
+          experimentalTranslation,
+          description: "Dictionary result not found. Showing experimental translation.",
+          loading: false,
+          error: false
+        });
+        return;
+      }
+
+      const errorMessage = response?.status === 404
         ? "We're still learning! Please try another translation."
         : "Something went wrong. Please try again.";
 
       setTranslationState({
         word: normalizedInput,
         translation: [],
+        experimentalTranslation: [],
         description: errorMessage,
         loading: false,
         error: true

--- a/frontend/lib/api.test.ts
+++ b/frontend/lib/api.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { fetchDailyWord, translateEnglishWord } from "@/lib/api";
+import { fetchDailyWord, translateEnglishWord, translateEnglishWordExperimental } from "@/lib/api";
 
 function jsonResponse(payload: unknown, status = 200) {
   return Promise.resolve(
@@ -35,6 +35,38 @@ describe("lib/api", () => {
     expect(response.success).toBe(true);
     expect(fetchMock).toHaveBeenCalledWith(
       "/api/translate",
+      expect.objectContaining({ method: "POST" })
+    );
+
+    const options = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(options.body).toBe(
+      JSON.stringify({
+        text: "hello",
+        source_lang: "en",
+        target_lang: "yo"
+      })
+    );
+  });
+
+  it("posts experimental translation requests with expected payload", async () => {
+    const fetchMock = vi.spyOn(global, "fetch").mockImplementation(() =>
+      jsonResponse({
+        success: true,
+        status: 200,
+        message: "ok",
+        data: {
+          source_word: "hello",
+          translation: ["ẹ káàbọ̀"],
+          to_language: "yo"
+        }
+      })
+    );
+
+    const response = await translateEnglishWordExperimental("hello");
+
+    expect(response.success).toBe(true);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/translate/llm",
       expect.objectContaining({ method: "POST" })
     );
 

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -84,6 +84,20 @@ export async function translateEnglishWord(text: string): Promise<ApiResponse<Tr
   });
 }
 
+export async function translateEnglishWordExperimental(text: string): Promise<ApiResponse<TranslationData>> {
+  return requestApi<TranslationData>("/translate/llm", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      text,
+      source_lang: "en",
+      target_lang: "yo"
+    })
+  });
+}
+
 export async function bulkUploadWords(
   textInput: string,
   dryRun: boolean,


### PR DESCRIPTION
## Summary
- restore a dedicated `/api/translate/llm` backend endpoint with shared translation request validation
- call DB and experimental LLM translation APIs in parallel from the Next frontend
- render experimental translations in a separate labeled section and cover the split flow in backend/frontend tests

## Testing
- docker compose run --build --rm backend python -m pytest tests/test_app.py
- npm test -- lib/api.test.ts components/home-page.test.tsx 'app/api/[...path]/route.test.ts'