### PR TITLE
Harden Gradient LLM service

### DIFF
--- a/alarino_backend/main/llm_service.py
+++ b/alarino_backend/main/llm_service.py
@@ -1,8 +1,8 @@
 # llm_service.py
-import os
 import json
-import time
+import os
 from abc import ABC, abstractmethod
+from functools import lru_cache
 from typing import List, Optional
 
 from gradient import Gradient
@@ -10,51 +10,83 @@ from gradient import Gradient
 from data.seed_data_utils import is_valid_yoruba_word
 from main import logger
 
+LANGUAGE_NAMES = {
+    "en": "English",
+    "yo": "Yoruba",
+}
+DEFAULT_TIMEOUT_SECONDS = float(os.getenv("GRADIENT_TIMEOUT_SECONDS", "20"))
+
+
 class LLMService(ABC):
     @abstractmethod
     def get_translation(self, text: str, source_lang: str, target_lang: str) -> Optional[List[str]]:
         pass
 
+
 class GradientLLMService(LLMService):
-    def __init__(self, access_key: Optional[str] = None, model: str = "openai-gpt-oss-120b", max_retries: int = 3):
+    def __init__(
+        self,
+        access_key: Optional[str] = None,
+        model: str = "openai-gpt-oss-120b",
+        max_retries: int = 3,
+        timeout: float = DEFAULT_TIMEOUT_SECONDS,
+    ):
         if not access_key:
             access_key = os.environ.get("GRADIENT_MODEL_ACCESS_KEY")
         if not access_key:
             raise ValueError("Gradient access key not provided or found in environment variables.")
-        
-        self.client = Gradient(model_access_key=access_key)
+
+        self.client = Gradient(
+            model_access_key=access_key,
+            max_retries=max_retries,
+            timeout=timeout,
+        )
         self.model = model
         self.max_retries = max_retries
 
-
-    def get_translation(self, text: str, source_lang: str, target_lang: str) -> Optional[List[str]]:
-        prompt = (
-            f"Translate the following English word to Yoruba with the proper diacritics: {text} "
-            "Provide 1 to 4 of the most accurate translations you are highly confident in. If you are not sure (99% confidence), provide an empty list"
+    def _build_prompt(self, text: str, source_lang: str, target_lang: str) -> str:
+        source_name = LANGUAGE_NAMES.get(source_lang, source_lang.upper())
+        target_name = LANGUAGE_NAMES.get(target_lang, target_lang.upper())
+        return (
+            f"Translate the following {source_name} word to {target_name} with the proper spelling and diacritics: {text}. "
+            "Provide 1 to 4 of the most accurate translations you are highly confident in. "
+            "If you are not sure (99% confidence), provide an empty list. "
             "The response must be a valid JSON array of strings, with no additional text or formatting. "
             "For example: [\"translation1\", \"translation2\"]"
         )
+
+    def get_translation(self, text: str, source_lang: str, target_lang: str) -> Optional[List[str]]:
+        prompt = self._build_prompt(text, source_lang, target_lang)
         for attempt in range(1, self.max_retries + 1):
             content = self.call_translate_llm(prompt, text)
             if content is None:
                 logger.warning(f"Attempt {attempt} failed, retrying...")
                 continue
             try:
-                # Validate and parse the response
                 translations = json.loads(content)
                 if not isinstance(translations, list) or not (1 <= len(translations) <= 5):
-                    logger.warning(f"LLM response for '{text}' was not a valid list of 1-3 strings: {content}")
-                    return None
+                    logger.warning(
+                        f"Attempt {attempt} returned an invalid translation list of 1-5 strings for '{text}': {content}"
+                    )
+                    continue
 
-                valid_translations = [t for t in translations if is_valid_yoruba_word(t)]
+                valid_translations = self._filter_valid_translations(translations, target_lang)
                 return valid_translations
 
             except json.JSONDecodeError:
-                logger.error(f"Failed to decode JSON from LLM response for '{text}': {content}")
-                return None
+                logger.error(f"Attempt {attempt} failed to decode JSON from LLM response for '{text}': {content}")
+                continue
             except Exception as e:
-                logger.error(f"Error getting translation from Gradient for '{text}': {e}")
-                return None
+                logger.error(f"Attempt {attempt} failed while processing Gradient response for '{text}': {e}")
+                continue
+
+        return None
+
+    def _filter_valid_translations(self, translations: List[str], target_lang: str) -> List[str]:
+        cleaned = [t.strip() for t in translations if isinstance(t, str) and t.strip()]
+        if target_lang == "yo":
+            return [t for t in cleaned if is_valid_yoruba_word(t)]
+        return cleaned
 
 
     def call_translate_llm(self, prompt: str, text: str) -> Optional[str]:
@@ -63,8 +95,6 @@ class GradientLLMService(LLMService):
                 {
                     "role": "user",
                     "content": prompt,
-                    "Reasoning": "medium",
-                    "response_format": "json",
                 }
             ],
             model=self.model,
@@ -72,6 +102,8 @@ class GradientLLMService(LLMService):
         content = response.choices[0].message.content
         return content
 
+
+@lru_cache(maxsize=1)
 def get_llm_service() -> Optional[LLMService]:
     """Factory function to get the configured LLM service."""
     access_key = os.environ.get("GRADIENT_MODEL_ACCESS_KEY")

--- a/alarino_backend/tests/test_llm_service.py
+++ b/alarino_backend/tests/test_llm_service.py
@@ -1,0 +1,114 @@
+from types import SimpleNamespace
+
+import pytest
+
+import main.llm_service as llm_service
+from main.llm_service import GradientLLMService, get_llm_service
+
+
+@pytest.fixture(autouse=True)
+def clear_llm_service_cache():
+    get_llm_service.cache_clear()
+    yield
+    get_llm_service.cache_clear()
+
+
+def test_get_llm_service_caches_client(monkeypatch):
+    created = []
+
+    class StubGradient:
+        def __init__(self, **kwargs):
+            created.append(kwargs)
+
+    monkeypatch.setenv("GRADIENT_MODEL_ACCESS_KEY", "test-key")
+    monkeypatch.setattr(llm_service, "Gradient", StubGradient)
+
+    first = get_llm_service()
+    second = get_llm_service()
+
+    assert first is second
+    assert len(created) == 1
+
+
+def test_gradient_service_uses_configured_timeout_and_retries(monkeypatch):
+    created = []
+
+    class StubGradient:
+        def __init__(self, **kwargs):
+            created.append(kwargs)
+
+    monkeypatch.setattr(llm_service, "Gradient", StubGradient)
+
+    GradientLLMService(access_key="test-key", max_retries=5, timeout=7.5)
+
+    assert created == [
+        {
+            "model_access_key": "test-key",
+            "max_retries": 5,
+            "timeout": 7.5,
+        }
+    ]
+
+
+def test_prompt_uses_requested_languages(monkeypatch):
+    monkeypatch.setattr(llm_service, "is_valid_yoruba_word", lambda text: True)
+
+    service = GradientLLMService(access_key="test-key")
+    service.client = SimpleNamespace()
+    prompts = []
+
+    def fake_call(prompt, text):
+        prompts.append(prompt)
+        return '["ọrẹ"]'
+
+    service.call_translate_llm = fake_call
+
+    result = service.get_translation("friend", "en", "yo")
+
+    assert result == ["ọrẹ"]
+    assert "English word to Yoruba" in prompts[0]
+
+
+def test_invalid_json_retries_until_success(monkeypatch):
+    monkeypatch.setattr(llm_service, "is_valid_yoruba_word", lambda text: True)
+
+    service = GradientLLMService(access_key="test-key", max_retries=3)
+    service.client = SimpleNamespace()
+    responses = iter([
+        "not json",
+        '{"oops": true}',
+        '["ọrẹ"]',
+    ])
+
+    service.call_translate_llm = lambda prompt, text: next(responses)
+
+    result = service.get_translation("friend", "en", "yo")
+
+    assert result == ["ọrẹ"]
+
+
+def test_call_translate_llm_sends_supported_message_shape():
+    captured = {}
+
+    class StubCompletions:
+        def create(self, **kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(
+                choices=[SimpleNamespace(message=SimpleNamespace(content='["ọrẹ"]'))]
+            )
+
+    service = GradientLLMService(access_key="test-key")
+    service.client = SimpleNamespace(chat=SimpleNamespace(completions=StubCompletions()))
+
+    content = service.call_translate_llm("translate this", "friend")
+
+    assert content == '["ọrẹ"]'
+    assert captured == {
+        "messages": [
+            {
+                "role": "user",
+                "content": "translate this",
+            }
+        ],
+        "model": "openai-gpt-oss-120b",
+    }


### PR DESCRIPTION
## Summary
- cache the Gradient LLM service instead of creating a new client on each request
- make the prompt respect the requested source and target languages
- remove unsupported message fields, add timeout wiring, and retry malformed responses
- add focused backend tests for prompt generation, retry behavior, request shape, and singleton caching

## Testing
- docker compose run --build --rm backend python -m pytest tests/test_app.py tests/test_llm_service.py