### PR TITLE
Switch backend to Gunicorn, add favicon, and update CI actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: "pip"
@@ -42,7 +42,7 @@ jobs:
         run: python -m pytest
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
 
@@ -70,7 +70,7 @@ jobs:
         run: docker compose -f docker-compose.yml -f docker-compose.prod.yml build backend frontend
 
       - name: Set up SSH
-        uses: webfactory/ssh-agent@v0.9.0
+        uses: webfactory/ssh-agent@v0.10.0
         with:
           ssh-private-key: ${{ secrets.SSH_KEY_DEPLOY }}
 

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -10,10 +10,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: "pip"
@@ -38,7 +38,7 @@ jobs:
         run: python -m pytest
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "npm"

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 frontend/node_modules
 frontend/.next
 frontend/coverage
+/AGENTS.md

--- a/alarino_backend/Dockerfile
+++ b/alarino_backend/Dockerfile
@@ -10,4 +10,4 @@ RUN pip install --no-cache-dir .
 ENV PYTHONUNBUFFERED=1
 EXPOSE 5001
 
-CMD ["sh", "-c", "echo \"[backend] Starting Flask API on port ${MAIN_PORT:-5001}\" && exec python -m alarino_backend.app"]
+CMD ["sh", "-c", "echo \"[backend] Starting Gunicorn on port ${MAIN_PORT:-5001}\" && exec gunicorn --bind 0.0.0.0:${MAIN_PORT:-5001} --workers ${GUNICORN_WORKERS:-2} --threads ${GUNICORN_THREADS:-4} --timeout ${GUNICORN_TIMEOUT:-120} alarino_backend.wsgi:app"]

--- a/alarino_backend/pyproject.toml
+++ b/alarino_backend/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
   "Flask-Migrate==4.1.0",
   "Flask-SQLAlchemy==3.1.1",
   "gradient==3.0.0b4",
+  "gunicorn==23.0.0",
   "psycopg2-binary==2.9.9",
   "python-dotenv==1.1.0",
   "SQLAlchemy==2.0.40",

--- a/alarino_backend/readme.md
+++ b/alarino_backend/readme.md
@@ -14,6 +14,9 @@ Provides API-only endpoints consumed by the Next.js frontend and direct API clie
 - `GET /api/health`
 
 ## Local Run (without Docker)
+Backend Python dependencies are expected to be installed in the Conda environment
+`alarino`.
+
 ```bash
 cd alarino_backend
 conda create -n alarino python=3.11
@@ -24,6 +27,8 @@ python -m alarino_backend.app
 
 If you prefer a plain virtualenv, create and activate `.venv`, then run the same
 `python -m pip install -e .[dev]` command.
+
+Docker production runs the API with Gunicorn via `alarino_backend.wsgi:app`.
 
 ## Environment Variables
 Required in `alarino_backend/.env`:
@@ -39,6 +44,9 @@ Optional:
 CORS_ALLOWED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000,https://alarino.com,https://www.alarino.com
 MAIN_PORT=5001
 SITE_DOMAIN=https://alarino.com
+GUNICORN_WORKERS=2
+GUNICORN_THREADS=4
+GUNICORN_TIMEOUT=120
 ```
 
 ## Tests

--- a/alarino_backend/src/alarino_backend/wsgi.py
+++ b/alarino_backend/src/alarino_backend/wsgi.py
@@ -1,0 +1,3 @@
+from alarino_backend.app import create_app
+
+app = create_app()

--- a/alarino_backend/tests/test_app.py
+++ b/alarino_backend/tests/test_app.py
@@ -26,6 +26,12 @@ def test_app_module_import_succeeds():
     assert imported is app_module
 
 
+def test_wsgi_module_exposes_app():
+    imported = importlib.import_module("alarino_backend.wsgi")
+
+    assert imported.app.name == "alarino_backend.app"
+
+
 def test_create_app_returns_flask_app(app):
     assert app.name == "alarino_backend.app"
 

--- a/docs/developer_setup.md
+++ b/docs/developer_setup.md
@@ -171,5 +171,6 @@ If `3000` or `5001` is occupied:
 ## Deployment Notes
 - CI workflow: `.github/workflows/deploy.yml`
 - Deploy target runs `backend`, `frontend`, and `caddy` in production compose.
+- The backend container serves Flask through Gunicorn (`alarino_backend.wsgi:app`).
 - Fresh droplet bootstrap: `scripts/bootstrap_droplet.sh` (guide: `docs/droplet_bootstrap.md`).
 - Deploy secrets: `SSH_KEY_DEPLOY`, `DO_USERNAME`, `DO_HOST`, `BACKEND_ENV_FILE`.

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -23,6 +23,10 @@ export const metadata: Metadata = {
   title: "Alarino | English to Yoruba Translator & Dictionary Online",
   description: "Alarino is a community-backed English to Yoruba translation dictionary with daily learning tools.",
   keywords: ["Yoruba", "English", "translation", "dictionary", "African languages"],
+  icons: {
+    icon: [{ url: "/alarino_logo_only.svg", type: "image/svg+xml" }],
+    shortcut: "/alarino_logo_only.svg"
+  },
   alternates: {
     canonical: "/"
   }


### PR DESCRIPTION
## Summary
- switch the backend container from the Flask development server to Gunicorn using `alarino_backend.wsgi:app`
- document that backend Python work should use the `alarino` Conda environment and add a Gunicorn/WGSI smoke test
- add the site favicon using the existing `alarino_logo_only.svg` asset
- update GitHub Actions versions for Node.js 24 compatibility

## Validation
- `conda run -n alarino python -m pytest alarino_backend/tests`