### PR TITLE
Bust favicon cache with versioned icon URL

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -24,8 +24,8 @@ export const metadata: Metadata = {
   description: "Alarino is a community-backed English to Yoruba translation dictionary with daily learning tools.",
   keywords: ["Yoruba", "English", "translation", "dictionary", "African languages"],
   icons: {
-    icon: [{ url: "/alarino_logo_only.svg", type: "image/svg+xml" }],
-    shortcut: "/alarino_logo_only.svg"
+    icon: [{ url: "/alarino_logo_only.svg?v=1", type: "image/svg+xml" }],
+    shortcut: "/alarino_logo_only.svg?v=1"
   },
   alternates: {
     canonical: "/"


### PR DESCRIPTION
## Summary
- add a version query string to the favicon URL so browsers fetch the updated icon after deploy

## Validation
- metadata change only