### PR TITLE
Schema evolution: sense layer, normalization, polysemy unblock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ node_modules
 frontend/node_modules
 frontend/.next
 frontend/coverage
-/AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# Repository Instructions
+
+## Environment
+- Backend Python dependencies are installed in the Conda environment `alarino`.
+- For backend Python commands that rely on installed packages, use `conda run -n alarino ...` or activate `alarino` first.
+- Do not assume the active shell is already using `alarino`; verify before running backend tests or import checks.
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/alarino_backend/migrations/versions/7e3a89c4b21f_phase1_hygiene.py
+++ b/alarino_backend/migrations/versions/7e3a89c4b21f_phase1_hygiene.py
@@ -1,0 +1,226 @@
+"""phase 1: drop redundant indexes, tighten nullability, dedupe examples
+
+Revision ID: 7e3a89c4b21f
+Revises: 1233050fe93a
+Create Date: 2026-04-25
+
+Implements Phase 1 of the schema evolution plan
+(docs/plans/schema_evolution_plan.md).
+
+OPERATOR PREFLIGHT (production):
+    Before applying, confirm the indexes being dropped are not in use:
+
+        SELECT indexrelname, idx_scan
+        FROM pg_stat_user_indexes
+        WHERE indexrelname IN (
+            'idx_words_language_word',
+            'idx_words_language',
+            'idx_missing_text_source_target',
+            'idx_proverbs_yoruba_text',
+            'idx_translations_source_word_id'
+        );
+
+    All idx_scan values should be at or near zero. Each redundant index is
+    covered by a unique constraint with the same or wider key, so the
+    planner has no reason to use it.
+
+    Also review _phase1_removed_examples in staging after the migration
+    runs. The Step 3 deduplication is intentionally non-reversible; the
+    sidecar table is the only audit trail of removed duplicate rows.
+
+REVERSIBILITY:
+    Steps 1 and 2 (index drops, NOT NULL tightening) are fully reversible.
+    Step 3 (Example dedup) is NOT reversible — the deleted duplicate rows
+    cannot be reconstructed from this migration alone.
+
+    Downgrade therefore FAILS LOUDLY by default rather than silently doing
+    a partial reversal that leaves deleted rows lost while restoring the
+    surrounding schema. Operators who explicitly accept the data loss
+    (e.g., dev-environment reset, restoring from a separate backup) can
+    set ALARINO_FORCE_DOWNGRADE_DATA_LOSS=1 in the environment to opt in.
+    With that env var set, the downgrade proceeds with the partial
+    reversal: it relaxes NOT NULL, restores indexes, and drops the unique
+    constraint, but leaves _phase1_removed_examples in place as the only
+    audit trail of the deleted rows.
+"""
+import os
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "7e3a89c4b21f"
+down_revision = "1233050fe93a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # ---- Step 1: drop redundant indexes (reversible) ----
+    with op.batch_alter_table("words", schema=None) as batch_op:
+        batch_op.drop_index("idx_words_language_word")
+        batch_op.drop_index("idx_words_language")
+
+    with op.batch_alter_table("missing_translations", schema=None) as batch_op:
+        batch_op.drop_index("idx_missing_text_source_target")
+
+    with op.batch_alter_table("proverbs", schema=None) as batch_op:
+        batch_op.drop_index("idx_proverbs_yoruba_text")
+
+    with op.batch_alter_table("translations", schema=None) as batch_op:
+        batch_op.drop_index("idx_translations_source_word_id")
+
+    # ---- Step 2: tighten nullability and defaults (reversible) ----
+    # Backfill any NULL created_at values before the NOT NULL constraint lands.
+    for table in (
+        "words",
+        "translations",
+        "daily_words",
+        "missing_translations",
+        "examples",
+        "proverbs",
+    ):
+        op.execute(
+            f"UPDATE {table} SET created_at = CURRENT_TIMESTAMP "
+            f"WHERE created_at IS NULL"
+        )
+    op.execute(
+        "UPDATE missing_translations SET hit_count = 1 WHERE hit_count IS NULL"
+    )
+
+    for table in (
+        "words",
+        "translations",
+        "daily_words",
+        "missing_translations",
+        "examples",
+        "proverbs",
+    ):
+        with op.batch_alter_table(table, schema=None) as batch_op:
+            batch_op.alter_column(
+                "created_at",
+                existing_type=sa.DateTime(),
+                nullable=False,
+                server_default=sa.func.now(),
+            )
+
+    with op.batch_alter_table("missing_translations", schema=None) as batch_op:
+        batch_op.alter_column(
+            "hit_count",
+            existing_type=sa.Integer(),
+            nullable=False,
+            server_default=sa.text("1"),
+        )
+
+    # ---- Step 3: deduplicate examples + add unique constraint (NOT reversible) ----
+    # Snapshot every duplicate row (any e_id that is not the minimum for its
+    # (translation_id, example_source, example_target) group) into a sidecar
+    # table for audit, then delete the duplicates and add the constraint.
+    op.execute(
+        """
+        CREATE TABLE _phase1_removed_examples (
+            e_id INTEGER,
+            translation_id INTEGER,
+            example_source TEXT,
+            example_target TEXT,
+            created_at TIMESTAMP,
+            removed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+        """
+    )
+    op.execute(
+        """
+        INSERT INTO _phase1_removed_examples
+            (e_id, translation_id, example_source, example_target, created_at)
+        SELECT e_id, translation_id, example_source, example_target, created_at
+        FROM examples
+        WHERE e_id NOT IN (
+            SELECT MIN(e_id)
+            FROM examples
+            GROUP BY translation_id, example_source, example_target
+        )
+        """
+    )
+    op.execute(
+        """
+        DELETE FROM examples
+        WHERE e_id NOT IN (
+            SELECT MIN(e_id)
+            FROM examples
+            GROUP BY translation_id, example_source, example_target
+        )
+        """
+    )
+    with op.batch_alter_table("examples", schema=None) as batch_op:
+        batch_op.create_unique_constraint(
+            "unique_example_per_translation",
+            ["translation_id", "example_source", "example_target"],
+        )
+
+
+def downgrade():
+    if os.environ.get("ALARINO_FORCE_DOWNGRADE_DATA_LOSS") != "1":
+        raise RuntimeError(
+            "Phase 1 (revision 7e3a89c4b21f) is NOT reversible: the duplicate "
+            "Example rows deleted in step 3 cannot be reconstructed from this "
+            "migration. Restore them from _phase1_removed_examples or from a "
+            "backup before downgrading. To proceed anyway and accept the data "
+            "loss, set ALARINO_FORCE_DOWNGRADE_DATA_LOSS=1 in the environment."
+        )
+
+    # ---- Step 3 reverse (PARTIAL): drop the unique constraint. Cannot restore
+    # deleted duplicate rows. _phase1_removed_examples is left in place so
+    # operators can copy data back manually if needed. ----
+    with op.batch_alter_table("examples", schema=None) as batch_op:
+        batch_op.drop_constraint(
+            "unique_example_per_translation", type_="unique"
+        )
+
+    # ---- Step 2 reverse: relax NOT NULL and drop server defaults. ----
+    with op.batch_alter_table("missing_translations", schema=None) as batch_op:
+        batch_op.alter_column(
+            "hit_count",
+            existing_type=sa.Integer(),
+            nullable=True,
+            server_default=None,
+        )
+
+    for table in (
+        "proverbs",
+        "examples",
+        "missing_translations",
+        "daily_words",
+        "translations",
+        "words",
+    ):
+        with op.batch_alter_table(table, schema=None) as batch_op:
+            batch_op.alter_column(
+                "created_at",
+                existing_type=sa.DateTime(),
+                nullable=True,
+                server_default=None,
+            )
+
+    # ---- Step 1 reverse: re-create the dropped indexes. ----
+    with op.batch_alter_table("translations", schema=None) as batch_op:
+        batch_op.create_index(
+            "idx_translations_source_word_id", ["source_word_id"], unique=False
+        )
+
+    with op.batch_alter_table("proverbs", schema=None) as batch_op:
+        batch_op.create_index(
+            "idx_proverbs_yoruba_text", ["yoruba_text"], unique=False
+        )
+
+    with op.batch_alter_table("missing_translations", schema=None) as batch_op:
+        batch_op.create_index(
+            "idx_missing_text_source_target",
+            ["text", "source_language", "target_language"],
+            unique=False,
+        )
+
+    with op.batch_alter_table("words", schema=None) as batch_op:
+        batch_op.create_index("idx_words_language", ["language"], unique=False)
+        batch_op.create_index(
+            "idx_words_language_word", ["language", "word"], unique=False
+        )

--- a/alarino_backend/migrations/versions/a91f5e3b8c42_phase6a_senses_table.py
+++ b/alarino_backend/migrations/versions/a91f5e3b8c42_phase6a_senses_table.py
@@ -1,0 +1,141 @@
+"""phase 6a: add senses table and translation metadata columns (additive)
+
+Revision ID: a91f5e3b8c42
+Revises: f6a182cd9e07
+Create Date: 2026-04-25
+
+Implements Phase 6a of the schema evolution plan
+(docs/plans/schema_evolution_plan.md).
+
+PURELY ADDITIVE. No existing column is dropped, no behavior changes.
+After this migration:
+  - A new senses table exists, with one row per existing Word, copying
+    that Word's part_of_speech.
+  - Translation has nullable source_sense_id, target_sense_id, note,
+    confidence, and provenance columns. Existing rows are backfilled
+    so source_sense_id and target_sense_id point at the lone sense of
+    the source/target word.
+  - Word.part_of_speech is intentionally kept (read paths still use it
+    until Phase 6c). Phase 6d drops it.
+  - The translation_id paths in Example, DailyWord, etc. are unchanged.
+
+This is the safest possible point in the sense-layer rollout: legacy
+schema and code keep working as before; the new structure is in place
+for Phase 6b/6c/6d to build on.
+
+REVERSIBILITY:
+    Fully reversible. Downgrade drops the new columns from translations
+    and drops the senses table. No data loss outside of the new columns
+    (which were either NULL or backfilled-from-existing-data).
+
+OPERATOR PREFLIGHT (production):
+    None required. The backfill is a deterministic 1:1 mapping.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "a91f5e3b8c42"
+down_revision = "f6a182cd9e07"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # ---- Step 1: create senses table ----
+    op.create_table(
+        "senses",
+        sa.Column("sense_id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "word_id",
+            sa.Integer(),
+            sa.ForeignKey("words.w_id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("part_of_speech", sa.String(length=20), nullable=True),
+        sa.Column("sense_label", sa.String(length=80), nullable=True),
+        sa.Column("definition", sa.Text(), nullable=True),
+        sa.Column("register", sa.String(length=40), nullable=True),
+        sa.Column("domain", sa.String(length=80), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    with op.batch_alter_table("senses", schema=None) as batch_op:
+        batch_op.create_index(
+            "idx_senses_word_id", ["word_id"], unique=False
+        )
+
+    # ---- Step 2: backfill one sense per existing Word, copying part_of_speech ----
+    connection = op.get_bind()
+    connection.execute(
+        sa.text(
+            "INSERT INTO senses (word_id, part_of_speech) "
+            "SELECT w_id, part_of_speech FROM words"
+        )
+    )
+
+    # ---- Step 3: add new columns to translations ----
+    with op.batch_alter_table("translations", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "source_sense_id",
+                sa.Integer(),
+                sa.ForeignKey(
+                    "senses.sense_id",
+                    name="fk_translations_source_sense_id",
+                    ondelete="CASCADE",
+                ),
+                nullable=True,
+            )
+        )
+        batch_op.add_column(
+            sa.Column(
+                "target_sense_id",
+                sa.Integer(),
+                sa.ForeignKey(
+                    "senses.sense_id",
+                    name="fk_translations_target_sense_id",
+                    ondelete="CASCADE",
+                ),
+                nullable=True,
+            )
+        )
+        batch_op.add_column(sa.Column("note", sa.Text(), nullable=True))
+        batch_op.add_column(sa.Column("confidence", sa.Float(), nullable=True))
+        batch_op.add_column(sa.Column("provenance", sa.String(length=40), nullable=True))
+
+    # ---- Step 4: backfill source_sense_id / target_sense_id from existing
+    # 1:1 word→sense mapping. Each existing Translation now points at the
+    # senses that were created in Step 2. ----
+    connection.execute(
+        sa.text(
+            "UPDATE translations "
+            "SET source_sense_id = (SELECT sense_id FROM senses WHERE senses.word_id = translations.source_word_id), "
+            "    target_sense_id = (SELECT sense_id FROM senses WHERE senses.word_id = translations.target_word_id)"
+        )
+    )
+
+
+def downgrade():
+    # ---- Reverse Step 3-4: drop the new translation columns ----
+    with op.batch_alter_table("translations", schema=None) as batch_op:
+        batch_op.drop_column("provenance")
+        batch_op.drop_column("confidence")
+        batch_op.drop_column("note")
+        batch_op.drop_constraint(
+            "fk_translations_target_sense_id", type_="foreignkey"
+        )
+        batch_op.drop_column("target_sense_id")
+        batch_op.drop_constraint(
+            "fk_translations_source_sense_id", type_="foreignkey"
+        )
+        batch_op.drop_column("source_sense_id")
+
+    # ---- Reverse Step 1-2: drop the senses table (and its rows) ----
+    with op.batch_alter_table("senses", schema=None) as batch_op:
+        batch_op.drop_index("idx_senses_word_id")
+    op.drop_table("senses")

--- a/alarino_backend/migrations/versions/b3d217fa094e_phase6b_examples_sense_columns.py
+++ b/alarino_backend/migrations/versions/b3d217fa094e_phase6b_examples_sense_columns.py
@@ -1,0 +1,95 @@
+"""phase 6b: add sense FKs to examples and backfill from translations
+
+Revision ID: b3d217fa094e
+Revises: a91f5e3b8c42
+Create Date: 2026-04-25
+
+Implements the schema portion of Phase 6b. Adds source_sense_id and
+target_sense_id columns to the examples table (nullable) and backfills
+them by copying from the linked Translation's sense IDs. Examples become
+sense-scoped going forward — an example for "bank — financial" should
+not appear under "bank — riverbank."
+
+The application-side write-path change (create_translation now ensures a
+default Sense for both words) ships in the same revision in code; this
+migration only handles the schema and backfill.
+
+translation_id is intentionally KEPT on examples until Phase 6d. Read
+paths during 6b/6c can use either the legacy translation_id link or
+the new sense-pair link; 6d drops translation_id once the sense-pair
+link is fully load-bearing.
+
+REVERSIBILITY:
+    Fully reversible. Downgrade drops the two new columns. No data loss
+    outside the new columns themselves (which were either NULL or
+    backfilled-from-Translation values that are still recoverable from
+    the linked Translation).
+
+OPERATOR PREFLIGHT (production):
+    None required. Backfill is a deterministic copy from each Example's
+    linked Translation. Phase 6a guaranteed every existing Translation
+    has both source_sense_id and target_sense_id set, so the copy is
+    well-defined for every Example.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "b3d217fa094e"
+down_revision = "a91f5e3b8c42"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # ---- Step 1: add sense FK columns to examples ----
+    with op.batch_alter_table("examples", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "source_sense_id",
+                sa.Integer(),
+                sa.ForeignKey(
+                    "senses.sense_id",
+                    name="fk_examples_source_sense_id",
+                    ondelete="CASCADE",
+                ),
+                nullable=True,
+            )
+        )
+        batch_op.add_column(
+            sa.Column(
+                "target_sense_id",
+                sa.Integer(),
+                sa.ForeignKey(
+                    "senses.sense_id",
+                    name="fk_examples_target_sense_id",
+                    ondelete="CASCADE",
+                ),
+                nullable=True,
+            )
+        )
+
+    # ---- Step 2: backfill from each Example's linked Translation ----
+    op.execute(
+        """
+        UPDATE examples
+        SET source_sense_id = (
+                SELECT t.source_sense_id FROM translations t WHERE t.t_id = examples.translation_id
+            ),
+            target_sense_id = (
+                SELECT t.target_sense_id FROM translations t WHERE t.t_id = examples.translation_id
+            )
+        """
+    )
+
+
+def downgrade():
+    with op.batch_alter_table("examples", schema=None) as batch_op:
+        batch_op.drop_constraint(
+            "fk_examples_target_sense_id", type_="foreignkey"
+        )
+        batch_op.drop_column("target_sense_id")
+        batch_op.drop_constraint(
+            "fk_examples_source_sense_id", type_="foreignkey"
+        )
+        batch_op.drop_column("source_sense_id")

--- a/alarino_backend/migrations/versions/c4b8e1a5d927_phase6b_pos_check.py
+++ b/alarino_backend/migrations/versions/c4b8e1a5d927_phase6b_pos_check.py
@@ -1,0 +1,104 @@
+"""phase 6b-followup: constrain part_of_speech to a typed enum
+
+Revision ID: c4b8e1a5d927
+Revises: b3d217fa094e
+Create Date: 2026-04-25
+
+Adds CHECK constraints to words.part_of_speech and senses.part_of_speech
+restricting non-NULL values to the canonical PartOfSpeech enum codes.
+Mirrors the language CHECK pattern from Phase 2.
+
+Lands BEFORE Phase 6c so the new sense-grouped /api/translate response
+ships with consistent POS values from day one. NULL remains valid (not
+every word needs POS marked); only non-NULL strings outside the enum are
+rejected.
+
+PREFLIGHT (built into the migration):
+    The migration scans existing words.part_of_speech and senses.part_of_speech
+    and aborts with a list of offending IDs if any non-NULL value is outside
+    the canonical set. At alarino's current data state most POS values are
+    NULL (the bulk-upload path doesn't set POS), so the preflight typically
+    passes with nothing to clean. If it doesn't pass, the operator normalizes
+    the strays manually before re-running.
+
+REVERSIBILITY:
+    Fully reversible. Downgrade drops both CHECK constraints. No data is
+    touched.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "c4b8e1a5d927"
+down_revision = "b3d217fa094e"
+branch_labels = None
+depends_on = None
+
+
+# Inlined to keep the migration frozen in time. Order matters for stable
+# CHECK-constraint SQL across re-runs.
+_ALLOWED_POS = (
+    "adj", "adv", "conj", "det", "interj", "n", "num", "part", "prep", "pron", "v",
+)
+
+
+def _check_clause() -> str:
+    return (
+        "part_of_speech IS NULL OR part_of_speech IN ("
+        + ", ".join(f"'{v}'" for v in _ALLOWED_POS)
+        + ")"
+    )
+
+
+def upgrade():
+    connection = op.get_bind()
+
+    # ---- Preflight: surface any stray non-canonical POS values ----
+    allowed_set = set(_ALLOWED_POS)
+
+    bad_words = [
+        row[0]
+        for row in connection.execute(
+            sa.text("SELECT w_id, part_of_speech FROM words WHERE part_of_speech IS NOT NULL")
+        ).fetchall()
+        if row[1] not in allowed_set
+    ]
+    bad_senses = [
+        row[0]
+        for row in connection.execute(
+            sa.text("SELECT sense_id, part_of_speech FROM senses WHERE part_of_speech IS NOT NULL")
+        ).fetchall()
+        if row[1] not in allowed_set
+    ]
+
+    if bad_words or bad_senses:
+        raise RuntimeError(
+            "Phase 6b POS-check (revision c4b8e1a5d927) cannot proceed: the "
+            "following rows have non-canonical part_of_speech values that are "
+            f"not in {sorted(allowed_set)!r}.\n"
+            f"  words.w_id: {bad_words}\n"
+            f"  senses.sense_id: {bad_senses}\n"
+            "Either normalize them to a canonical short code (e.g., 'noun' -> 'n', "
+            "'Noun' -> 'n') or set them to NULL, then re-run the migration."
+        )
+
+    # ---- Add CHECK constraints ----
+    with op.batch_alter_table("words", schema=None) as batch_op:
+        batch_op.create_check_constraint(
+            "ck_words_part_of_speech_valid", _check_clause()
+        )
+    with op.batch_alter_table("senses", schema=None) as batch_op:
+        batch_op.create_check_constraint(
+            "ck_senses_part_of_speech_valid", _check_clause()
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("senses", schema=None) as batch_op:
+        batch_op.drop_constraint(
+            "ck_senses_part_of_speech_valid", type_="check"
+        )
+    with op.batch_alter_table("words", schema=None) as batch_op:
+        batch_op.drop_constraint(
+            "ck_words_part_of_speech_valid", type_="check"
+        )

--- a/alarino_backend/migrations/versions/c8d4f1a2b903_phase2_language_check_drop_user_ip.py
+++ b/alarino_backend/migrations/versions/c8d4f1a2b903_phase2_language_check_drop_user_ip.py
@@ -1,0 +1,121 @@
+"""phase 2: add language CHECK constraints, drop missing_translations.user_ip
+
+Revision ID: c8d4f1a2b903
+Revises: 7e3a89c4b21f
+Create Date: 2026-04-25
+
+Implements Phase 2 of the schema evolution plan
+(docs/plans/schema_evolution_plan.md).
+
+OPERATOR PREFLIGHT (production):
+    Before applying, verify that no rows carry a non-canonical language
+    code. The CHECK constraint will fail to apply otherwise:
+
+        SELECT DISTINCT language FROM words;
+        SELECT DISTINCT source_language FROM missing_translations;
+        SELECT DISTINCT target_language FROM missing_translations;
+
+    All values must be 'en' or 'yo'. If anything else appears, decide
+    case-by-case whether to normalize or delete the offending rows before
+    re-running the migration.
+
+    Also review _phase2_removed_user_ips after the migration runs. The
+    column drop is intentionally non-reversible (the original IP values
+    cannot be reconstructed); the sidecar table is the only audit trail.
+
+REVERSIBILITY:
+    The CHECK constraints are reversible (drop them on downgrade).
+    The user_ip column drop is NOT reversible — the original IP values
+    cannot be reconstructed from this migration alone.
+
+    Downgrade therefore FAILS LOUDLY by default rather than silently doing
+    a partial reversal that re-adds an empty user_ip column while leaving
+    the original data lost. Operators who explicitly accept the data loss
+    can set ALARINO_FORCE_DOWNGRADE_DATA_LOSS=1 in the environment to opt
+    in. With that env var set, the downgrade proceeds with the partial
+    reversal: it drops the CHECK constraints and re-adds user_ip as a
+    nullable VARCHAR(45), and leaves _phase2_removed_user_ips in place as
+    the only audit trail of the dropped values.
+"""
+import os
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "c8d4f1a2b903"
+down_revision = "7e3a89c4b21f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # ---- Step 1 (DATA-DESTRUCTIVE): snapshot user_ip then drop the column ----
+    op.execute(
+        """
+        CREATE TABLE _phase2_removed_user_ips (
+            m_id INTEGER,
+            text VARCHAR(200),
+            source_language VARCHAR(3),
+            target_language VARCHAR(3),
+            user_ip VARCHAR(45),
+            removed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+        """
+    )
+    op.execute(
+        """
+        INSERT INTO _phase2_removed_user_ips
+            (m_id, text, source_language, target_language, user_ip)
+        SELECT m_id, text, source_language, target_language, user_ip
+        FROM missing_translations
+        WHERE user_ip IS NOT NULL
+        """
+    )
+    with op.batch_alter_table("missing_translations", schema=None) as batch_op:
+        batch_op.drop_column("user_ip")
+
+    # ---- Step 2: add CHECK constraints on language columns ----
+    with op.batch_alter_table("words", schema=None) as batch_op:
+        batch_op.create_check_constraint(
+            "ck_words_language_valid",
+            "language IN ('en', 'yo')",
+        )
+    with op.batch_alter_table("missing_translations", schema=None) as batch_op:
+        batch_op.create_check_constraint(
+            "ck_missing_translations_source_language_valid",
+            "source_language IN ('en', 'yo')",
+        )
+        batch_op.create_check_constraint(
+            "ck_missing_translations_target_language_valid",
+            "target_language IN ('en', 'yo')",
+        )
+
+
+def downgrade():
+    if os.environ.get("ALARINO_FORCE_DOWNGRADE_DATA_LOSS") != "1":
+        raise RuntimeError(
+            "Phase 2 (revision c8d4f1a2b903) is NOT reversible: the user_ip "
+            "values dropped from missing_translations cannot be reconstructed "
+            "from this migration. Restore them from _phase2_removed_user_ips "
+            "or from a backup before downgrading. To proceed anyway and accept "
+            "the data loss, set ALARINO_FORCE_DOWNGRADE_DATA_LOSS=1 in the "
+            "environment."
+        )
+
+    # ---- Step 2 reverse: drop CHECK constraints ----
+    with op.batch_alter_table("missing_translations", schema=None) as batch_op:
+        batch_op.drop_constraint(
+            "ck_missing_translations_target_language_valid", type_="check"
+        )
+        batch_op.drop_constraint(
+            "ck_missing_translations_source_language_valid", type_="check"
+        )
+    with op.batch_alter_table("words", schema=None) as batch_op:
+        batch_op.drop_constraint("ck_words_language_valid", type_="check")
+
+    # ---- Step 1 reverse (PARTIAL): re-add user_ip column. Original values
+    # cannot be restored from this migration; copy from _phase2_removed_user_ips
+    # if needed. ----
+    with op.batch_alter_table("missing_translations", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("user_ip", sa.String(length=45), nullable=True))

--- a/alarino_backend/migrations/versions/d2e8f60a7c14_phase3_proverb_words.py
+++ b/alarino_backend/migrations/versions/d2e8f60a7c14_phase3_proverb_words.py
@@ -1,0 +1,178 @@
+r"""phase 3: add proverb_words join table and backfill from existing proverbs
+
+Revision ID: d2e8f60a7c14
+Revises: c8d4f1a2b903
+Create Date: 2026-04-25
+
+Implements Phase 3 of the schema evolution plan
+(docs/plans/schema_evolution_plan.md).
+
+The backfill mirrors the runtime semantics of seed_data_utils.add_proverb:
+tokenize each proverb (re.findall(r'\b\w+\b', ...)), normalize each token
+(strip punctuation, lowercase, NFC), validate it against the same
+language-specific character set used at runtime, then either link to an
+existing Word row or CREATE one if it does not exist. Tokens that fail
+validation are silently skipped (matching add_word's None-return path).
+
+The validation rules are inlined here rather than imported from
+seed_data_utils so the migration stays frozen in time — if the runtime
+rules ever change, this migration still represents what was extracted at
+the time it ran.
+
+Position values are 0-indexed within each language sequence and only
+increment for tokens that result in a Word link, so they stay dense even
+when some tokens fail validation.
+
+REVERSIBILITY:
+    Fully reversible. Downgrade drops the proverb_words table. Word rows
+    that this migration created are intentionally left in place — they are
+    legitimate vocabulary entries, not migration artifacts.
+"""
+import re
+import unicodedata
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "d2e8f60a7c14"
+down_revision = "c8d4f1a2b903"
+branch_labels = None
+depends_on = None
+
+
+# ---- Inlined runtime word-validation rules (frozen as of seed_data_utils
+# at the time this migration was written). Keep in sync with the runtime
+# only when intentionally re-running the backfill on already-migrated DBs. ----
+
+_YORUBA_CONSONANTS = "bdfghjklmnprstwygbṣ"
+_YORUBA_VOWELS = "aàáeèéẹẹ̀ẹ́iìíoòóọọ̀ọ́uùú"
+_YORUBA_NASAL_VOWELS = "mḿm̀nńǹ"
+_YORUBA_CHARACTER_SET = (
+    _YORUBA_CONSONANTS + _YORUBA_VOWELS + _YORUBA_NASAL_VOWELS
+)
+
+
+def _normalize_token(token: str) -> str:
+    cleaned = token.strip().strip(" ,.?!()").lower()
+    return unicodedata.normalize("NFC", cleaned)
+
+
+def _is_valid_yoruba_word(word: str) -> bool:
+    if not word:
+        return False
+    valid_chars = unicodedata.normalize("NFC", _YORUBA_CHARACTER_SET + "'- ")
+    pattern = f"^[{re.escape(valid_chars)}]+$"
+    return bool(re.match(pattern, word, re.UNICODE))
+
+
+def _is_valid_english_word(word: str) -> bool:
+    if not word:
+        return False
+    return bool(re.match(r"^[a-z'\- ]+$", word, re.UNICODE))
+
+
+def _get_or_create_word_id(connection, language: str, raw_token: str):
+    normalized = _normalize_token(raw_token)
+    if not normalized:
+        return None
+    if language == "yo" and not _is_valid_yoruba_word(normalized):
+        return None
+    if language == "en" and not _is_valid_english_word(normalized):
+        return None
+    row = connection.execute(
+        sa.text(
+            "SELECT w_id FROM words "
+            "WHERE language = :lang AND word = :word"
+        ),
+        {"lang": language, "word": normalized},
+    ).fetchone()
+    if row is not None:
+        return row[0]
+    # Mirror add_word()'s create-if-missing semantics so pre-Phase-3
+    # proverbs whose tokens are not yet in the words table still become
+    # discoverable through get_proverbs_containing().
+    connection.execute(
+        sa.text(
+            "INSERT INTO words (language, word) VALUES (:lang, :word)"
+        ),
+        {"lang": language, "word": normalized},
+    )
+    row = connection.execute(
+        sa.text(
+            "SELECT w_id FROM words "
+            "WHERE language = :lang AND word = :word"
+        ),
+        {"lang": language, "word": normalized},
+    ).fetchone()
+    return row[0]
+
+
+def upgrade():
+    op.create_table(
+        "proverb_words",
+        sa.Column(
+            "proverb_id",
+            sa.Integer(),
+            sa.ForeignKey("proverbs.p_id", ondelete="CASCADE"),
+            primary_key=True,
+            nullable=False,
+        ),
+        sa.Column(
+            "word_id",
+            sa.Integer(),
+            sa.ForeignKey("words.w_id", ondelete="CASCADE"),
+            primary_key=True,
+            nullable=False,
+        ),
+        sa.Column("language", sa.String(length=3), primary_key=True, nullable=False),
+        sa.Column("position", sa.Integer(), primary_key=True, nullable=False),
+        sa.CheckConstraint(
+            "language IN ('en', 'yo')",
+            name="ck_proverb_words_language_valid",
+        ),
+    )
+    with op.batch_alter_table("proverb_words", schema=None) as batch_op:
+        batch_op.create_index(
+            "idx_proverb_words_word_id", ["word_id"], unique=False
+        )
+
+    # Backfill from existing proverbs.
+    connection = op.get_bind()
+    proverbs = connection.execute(
+        sa.text("SELECT p_id, yoruba_text, english_text FROM proverbs")
+    ).fetchall()
+
+    for proverb_row in proverbs:
+        p_id = proverb_row[0]
+        for language_code, raw_text in (
+            ("yo", proverb_row[1]),
+            ("en", proverb_row[2]),
+        ):
+            position = 0
+            for token in re.findall(r"\b\w+\b", raw_text or ""):
+                word_id = _get_or_create_word_id(
+                    connection, language_code, token
+                )
+                if word_id is None:
+                    continue
+                connection.execute(
+                    sa.text(
+                        "INSERT INTO proverb_words "
+                        "(proverb_id, word_id, language, position) "
+                        "VALUES (:p, :w, :lang, :pos)"
+                    ),
+                    {
+                        "p": p_id,
+                        "w": word_id,
+                        "lang": language_code,
+                        "pos": position,
+                    },
+                )
+                position += 1
+
+
+def downgrade():
+    with op.batch_alter_table("proverb_words", schema=None) as batch_op:
+        batch_op.drop_index("idx_proverb_words_word_id")
+    op.drop_table("proverb_words")

--- a/alarino_backend/migrations/versions/d8a3f0b71e5c_phase6d_drop_legacy.py
+++ b/alarino_backend/migrations/versions/d8a3f0b71e5c_phase6d_drop_legacy.py
@@ -1,0 +1,188 @@
+"""phase 6d: drop legacy sense-layer columns and tighten sense FKs
+
+Revision ID: d8a3f0b71e5c
+Revises: c4b8e1a5d927
+Create Date: 2026-04-25
+
+Closes the sense-layer cutover:
+  - Translation source_sense_id and target_sense_id become NOT NULL.
+  - Examples lose translation_id and the unique_example_per_translation
+    constraint; new uniqueness is on (source_sense_id, target_sense_id,
+    example_source, example_target).
+  - Word.part_of_speech is dropped (POS is sense-scoped now).
+
+PREFLIGHT (built into the migration):
+  - Every Translation must have non-NULL source_sense_id and
+    target_sense_id. Phase 6a backfilled all existing rows; Phase 6b's
+    create_translation populates them on every new Translation. A stray
+    Translation inserted via raw SQL between 6a and 6d would surface
+    here.
+  - Every Example must have non-NULL source_sense_id and target_sense_id.
+    Phase 6b backfilled existing rows; new Examples must set them
+    explicitly. Strays surface here.
+
+REVERSIBILITY:
+  - Tightening Translation sense FKs to NOT NULL is reversible (downgrade
+    relaxes them).
+  - Dropping Word.part_of_speech is data-destructive (the column held
+    POS values copied to Sense.part_of_speech in Phase 6a; the Sense
+    column carries the same data and is not affected). Downgrade
+    re-adds the Word column nullable but does NOT restore values —
+    operators that need them can copy from senses.part_of_speech via
+    the one-sense-per-word mapping that Phase 6a established.
+  - Dropping Example.translation_id is data-destructive (the link to
+    parent Translation is lost; sense-pair link via source_sense_id /
+    target_sense_id replaces it). Downgrade re-adds the column nullable
+    but does NOT restore values.
+
+  Therefore downgrade FAILS LOUDLY by default. Set
+  ALARINO_FORCE_DOWNGRADE_DATA_LOSS=1 to opt into the partial reversal
+  that re-adds the columns empty.
+"""
+import os
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "d8a3f0b71e5c"
+down_revision = "c4b8e1a5d927"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    connection = op.get_bind()
+
+    # ---- Preflight: Translation sense FKs must all be non-NULL ----
+    null_translation_senses = [
+        row[0]
+        for row in connection.execute(
+            sa.text(
+                "SELECT t_id FROM translations "
+                "WHERE source_sense_id IS NULL OR target_sense_id IS NULL"
+            )
+        ).fetchall()
+    ]
+    if null_translation_senses:
+        raise RuntimeError(
+            "Phase 6d (revision d8a3f0b71e5c) cannot proceed: the following "
+            f"translations have NULL sense FKs: {null_translation_senses}. "
+            "Phase 6a backfilled all existing rows and Phase 6b's create_translation "
+            "populates new rows; stray Translations created via raw SQL between "
+            "6a and 6d may have NULL sense FKs. Either delete them or set their "
+            "source_sense_id/target_sense_id manually before re-running."
+        )
+
+    # ---- Preflight: Example sense FKs must all be non-NULL (only matters
+    # because we're dropping translation_id; an Example with NULL sense FKs
+    # AND no translation_id would be unattached to anything). ----
+    null_example_senses = [
+        row[0]
+        for row in connection.execute(
+            sa.text(
+                "SELECT e_id FROM examples "
+                "WHERE source_sense_id IS NULL OR target_sense_id IS NULL"
+            )
+        ).fetchall()
+    ]
+    if null_example_senses:
+        raise RuntimeError(
+            "Phase 6d (revision d8a3f0b71e5c) cannot proceed: the following "
+            f"examples have NULL sense FKs: {null_example_senses}. Dropping "
+            "translation_id would orphan them. Either delete them or set their "
+            "source_sense_id/target_sense_id manually (e.g., copy from the "
+            "linked Translation via examples.translation_id) before re-running."
+        )
+
+    # ---- Step 1: tighten Translation sense FKs ----
+    with op.batch_alter_table("translations", schema=None) as batch_op:
+        batch_op.alter_column(
+            "source_sense_id",
+            existing_type=sa.Integer(),
+            nullable=False,
+        )
+        batch_op.alter_column(
+            "target_sense_id",
+            existing_type=sa.Integer(),
+            nullable=False,
+        )
+
+    # ---- Step 2: replace Example uniqueness, drop translation_id ----
+    with op.batch_alter_table("examples", schema=None) as batch_op:
+        batch_op.drop_constraint(
+            "unique_example_per_translation", type_="unique"
+        )
+        batch_op.create_unique_constraint(
+            "unique_example_per_sense_pair",
+            ["source_sense_id", "target_sense_id", "example_source", "example_target"],
+        )
+        batch_op.drop_column("translation_id")
+
+    # ---- Step 3: drop Word.part_of_speech and its CHECK constraint ----
+    with op.batch_alter_table("words", schema=None) as batch_op:
+        batch_op.drop_constraint(
+            "ck_words_part_of_speech_valid", type_="check"
+        )
+        batch_op.drop_column("part_of_speech")
+
+
+def downgrade():
+    if os.environ.get("ALARINO_FORCE_DOWNGRADE_DATA_LOSS") != "1":
+        raise RuntimeError(
+            "Phase 6d (revision d8a3f0b71e5c) is NOT cleanly reversible: "
+            "Word.part_of_speech and Example.translation_id were dropped. "
+            "Sense.part_of_speech carries the same POS data via the one-sense-"
+            "per-word mapping Phase 6a established; operators who need to "
+            "restore Example.translation_id values must derive them from the "
+            "(source_sense_id, target_sense_id) pair. To proceed with the "
+            "partial reversal that re-adds the columns empty and relaxes the "
+            "NOT NULL constraints, set ALARINO_FORCE_DOWNGRADE_DATA_LOSS=1 "
+            "in the environment."
+        )
+
+    # ---- Step 3 reverse: re-add Word.part_of_speech (empty) + CHECK ----
+    with op.batch_alter_table("words", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column("part_of_speech", sa.String(length=20), nullable=True)
+        )
+        batch_op.create_check_constraint(
+            "ck_words_part_of_speech_valid",
+            "part_of_speech IS NULL OR part_of_speech IN ("
+            "'adj', 'adv', 'conj', 'det', 'interj', 'n', 'num', 'part', 'prep', 'pron', 'v')",
+        )
+
+    # ---- Step 2 reverse: re-add Example.translation_id (empty) + restore unique ----
+    with op.batch_alter_table("examples", schema=None) as batch_op:
+        batch_op.drop_constraint(
+            "unique_example_per_sense_pair", type_="unique"
+        )
+        batch_op.add_column(
+            sa.Column(
+                "translation_id",
+                sa.Integer(),
+                sa.ForeignKey(
+                    "translations.t_id",
+                    name="fk_examples_translation_id",
+                    ondelete="CASCADE",
+                ),
+                nullable=True,
+            )
+        )
+        batch_op.create_unique_constraint(
+            "unique_example_per_translation",
+            ["translation_id", "example_source", "example_target"],
+        )
+
+    # ---- Step 1 reverse: relax Translation sense FKs ----
+    with op.batch_alter_table("translations", schema=None) as batch_op:
+        batch_op.alter_column(
+            "target_sense_id",
+            existing_type=sa.Integer(),
+            nullable=True,
+        )
+        batch_op.alter_column(
+            "source_sense_id",
+            existing_type=sa.Integer(),
+            nullable=True,
+        )

--- a/alarino_backend/migrations/versions/e5a9c2b48d76_phase3a_normalize_proverb_text.py
+++ b/alarino_backend/migrations/versions/e5a9c2b48d76_phase3a_normalize_proverb_text.py
@@ -1,0 +1,169 @@
+"""phase 3a: NFC-normalize existing Proverb.yoruba_text and english_text
+
+Revision ID: e5a9c2b48d76
+Revises: d2e8f60a7c14
+Create Date: 2026-04-25
+
+Companion to Phase 3. The runtime add_proverb() path historically wrote
+yoruba_text and english_text without Unicode normalization, so existing
+rows can be in mixed forms (some NFC, some NFD, some inconsistent within
+a single row). After this revision, runtime writes go through normalize_text
+and only insert NFC forms; this migration brings existing data into the
+same canonical form.
+
+Strategy:
+    1. Snapshot every proverb row (original text) into _phase3a_pre_normalize_proverbs.
+    2. Compute NFC of each (yoruba_text, english_text) pair in Python.
+    3. Group by the NFC pair. For groups with multiple rows, keep min(p_id)
+       and delete the rest (their original text is in the sidecar and the
+       DELETE itself is logged to _phase3a_removed_proverb_duplicates).
+    4. UPDATE remaining rows to their NFC values.
+
+OPERATOR PREFLIGHT:
+    Estimate impact before running:
+        SELECT count(*) FROM proverbs;
+        -- After running, compare:
+        SELECT count(*) FROM _phase3a_removed_proverb_duplicates;
+
+    If the removed-duplicates count is non-zero, review the sidecar in
+    staging before running in prod.
+
+REVERSIBILITY:
+    The UPDATE step is reversible from _phase3a_pre_normalize_proverbs.
+    The DELETE step (when normalization-collision duplicates exist) is
+    NOT reversible from this migration alone. Downgrade therefore FAILS
+    LOUDLY by default; set ALARINO_FORCE_DOWNGRADE_DATA_LOSS=1 to opt
+    into the partial reversal that restores text values from the sidecar
+    but cannot restore deleted rows.
+"""
+import os
+import unicodedata
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "e5a9c2b48d76"
+down_revision = "d2e8f60a7c14"
+branch_labels = None
+depends_on = None
+
+
+def _nfc(text):
+    if text is None:
+        return None
+    return unicodedata.normalize("NFC", text)
+
+
+def upgrade():
+    op.execute(
+        """
+        CREATE TABLE _phase3a_pre_normalize_proverbs (
+            p_id INTEGER PRIMARY KEY,
+            original_yoruba_text TEXT,
+            original_english_text TEXT,
+            snapshotted_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+        """
+    )
+    op.execute(
+        """
+        CREATE TABLE _phase3a_removed_proverb_duplicates (
+            p_id INTEGER,
+            original_yoruba_text TEXT,
+            original_english_text TEXT,
+            kept_p_id INTEGER,
+            removed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+        """
+    )
+
+    connection = op.get_bind()
+    rows = connection.execute(
+        sa.text("SELECT p_id, yoruba_text, english_text FROM proverbs")
+    ).fetchall()
+
+    # Snapshot every row's original text.
+    for row in rows:
+        connection.execute(
+            sa.text(
+                "INSERT INTO _phase3a_pre_normalize_proverbs "
+                "(p_id, original_yoruba_text, original_english_text) "
+                "VALUES (:p, :y, :e)"
+            ),
+            {"p": row[0], "y": row[1], "e": row[2]},
+        )
+
+    # Group by NFC pair to find collision-duplicates.
+    groups: dict[tuple[str, str], list[tuple[int, str, str]]] = {}
+    for p_id, y_text, e_text in rows:
+        key = (_nfc(y_text) or "", _nfc(e_text) or "")
+        groups.setdefault(key, []).append((p_id, y_text, e_text))
+
+    rows_to_delete: list[tuple[int, str, str, int]] = []
+    rows_to_update: list[tuple[int, str, str]] = []
+    for (y_nfc, e_nfc), group in groups.items():
+        group.sort(key=lambda r: r[0])
+        keeper_p_id = group[0][0]
+        for p_id, y_orig, e_orig in group[1:]:
+            rows_to_delete.append((p_id, y_orig, e_orig, keeper_p_id))
+        # Update keeper to NFC if it isn't already.
+        keeper_y_orig = group[0][1]
+        keeper_e_orig = group[0][2]
+        if keeper_y_orig != y_nfc or keeper_e_orig != e_nfc:
+            rows_to_update.append((keeper_p_id, y_nfc, e_nfc))
+
+    # Log + delete duplicates first so the UPDATE doesn't trip the unique
+    # constraint when one row in a group is already NFC.
+    for p_id, y_orig, e_orig, keeper_p_id in rows_to_delete:
+        connection.execute(
+            sa.text(
+                "INSERT INTO _phase3a_removed_proverb_duplicates "
+                "(p_id, original_yoruba_text, original_english_text, kept_p_id) "
+                "VALUES (:p, :y, :e, :k)"
+            ),
+            {"p": p_id, "y": y_orig, "e": e_orig, "k": keeper_p_id},
+        )
+        connection.execute(
+            sa.text("DELETE FROM proverbs WHERE p_id = :p"),
+            {"p": p_id},
+        )
+
+    # Now safely update keepers to NFC form.
+    for p_id, y_nfc, e_nfc in rows_to_update:
+        connection.execute(
+            sa.text(
+                "UPDATE proverbs SET yoruba_text = :y, english_text = :e "
+                "WHERE p_id = :p"
+            ),
+            {"p": p_id, "y": y_nfc, "e": e_nfc},
+        )
+
+
+def downgrade():
+    if os.environ.get("ALARINO_FORCE_DOWNGRADE_DATA_LOSS") != "1":
+        raise RuntimeError(
+            "Phase 3a (revision e5a9c2b48d76) is NOT cleanly reversible if "
+            "any normalization-collision duplicates were removed. Inspect "
+            "_phase3a_removed_proverb_duplicates first; if it is non-empty "
+            "those rows cannot be restored from this migration. To proceed "
+            "with the partial reversal (restore text values from "
+            "_phase3a_pre_normalize_proverbs, leave deleted rows lost), set "
+            "ALARINO_FORCE_DOWNGRADE_DATA_LOSS=1 in the environment."
+        )
+
+    connection = op.get_bind()
+    snapshot_rows = connection.execute(
+        sa.text(
+            "SELECT p_id, original_yoruba_text, original_english_text "
+            "FROM _phase3a_pre_normalize_proverbs"
+        )
+    ).fetchall()
+    for p_id, y_orig, e_orig in snapshot_rows:
+        connection.execute(
+            sa.text(
+                "UPDATE proverbs SET yoruba_text = :y, english_text = :e "
+                "WHERE p_id = :p"
+            ),
+            {"p": p_id, "y": y_orig, "e": e_orig},
+        )

--- a/alarino_backend/migrations/versions/e7c195a8b340_phase7_rename_word_to_text.py
+++ b/alarino_backend/migrations/versions/e7c195a8b340_phase7_rename_word_to_text.py
@@ -1,0 +1,53 @@
+"""phase 7: rename words.word column to words.text
+
+Revision ID: e7c195a8b340
+Revises: d8a3f0b71e5c
+Create Date: 2026-04-25
+
+Final phase of the schema evolution plan: rename the lexical-string column
+on the words table from `word` to `text`. The class is still named Word
+(it represents a vocabulary entry); only the column was renamed for clarity
+since `word.word` was awkward and `word.text` reads naturally.
+
+Atomic: schema rename + the (language, word) unique-constraint rename
+land in a single revision because every code path that reads or writes
+this column is updated in the same release.
+
+OPERATOR PREFLIGHT (production):
+    None required. Pure rename — no data loss, no constraint drift.
+
+REVERSIBILITY:
+    Fully reversible. Downgrade renames the column back to `word` and
+    restores the unique_language_word constraint name. Data is preserved
+    end-to-end.
+"""
+from alembic import op
+
+
+revision = "e7c195a8b340"
+down_revision = "d8a3f0b71e5c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Split into two batches: combining drop_constraint + alter_column +
+    # create_unique_constraint in a single batch_alter_table block on SQLite
+    # silently loses the new constraint when the table is reconstructed.
+    with op.batch_alter_table("words", schema=None) as batch_op:
+        batch_op.drop_constraint("unique_language_word", type_="unique")
+        batch_op.alter_column("word", new_column_name="text")
+    with op.batch_alter_table("words", schema=None) as batch_op:
+        batch_op.create_unique_constraint(
+            "unique_language_text", ["language", "text"]
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("words", schema=None) as batch_op:
+        batch_op.drop_constraint("unique_language_text", type_="unique")
+        batch_op.alter_column("text", new_column_name="word")
+    with op.batch_alter_table("words", schema=None) as batch_op:
+        batch_op.create_unique_constraint(
+            "unique_language_word", ["language", "word"]
+        )

--- a/alarino_backend/migrations/versions/f0e8d3a4c612_phase7_bugfix_polysemy_and_dailyword_reuse.py
+++ b/alarino_backend/migrations/versions/f0e8d3a4c612_phase7_bugfix_polysemy_and_dailyword_reuse.py
@@ -1,0 +1,90 @@
+"""phase 7 bug-fix: relax DailyWord uniqueness, move Translation uniqueness to sense pair
+
+Revision ID: f0e8d3a4c612
+Revises: e7c195a8b340
+Create Date: 2026-04-25
+
+Two schema bugs surfaced after the Phase 5/6 cutover:
+
+1. DailyWord.translation_id was made UNIQUE in Phase 5, but
+   find_random_unused_translation defaults to can_reuse=True. Once a
+   translation has been used as a daily word once, the next time the
+   picker selects it the INSERT into daily_words violates the unique
+   constraint and the endpoint 500s. Fix: drop the unique constraint.
+   Date uniqueness (one daily word per date) is preserved via the date
+   column's existing UNIQUE.
+
+2. translations was UNIQUE on (source_word_id, target_word_id) — carried
+   over from before the sense layer. That blocks the polysemy use case
+   the sense layer is supposed to unlock: "bank (financial) -> X" and
+   "bank (river) -> X" can't coexist if both target the same surface
+   word. Fix: drop unique_translation_pair, replace with
+   unique_translation_sense_pair on (source_sense_id, target_sense_id).
+   Phase 6d already made the sense FKs NOT NULL, so the sense pair is
+   well-defined for every Translation.
+
+The dropped translations word-pair constraint also implicitly covered
+source_word_id with its prefix index. Add an explicit
+idx_translations_source_word_id to keep the bidirectional translate()
+join from regressing to a scan.
+
+REVERSIBILITY:
+    Fully reversible. Downgrade restores both unique constraints and
+    drops the new index. The translations data must already satisfy
+    the original (source_word_id, target_word_id) uniqueness for the
+    downgrade to apply cleanly — operators who curated polysemy that
+    relies on the new sense-pair uniqueness will need to deduplicate
+    before downgrading.
+"""
+from alembic import op
+
+
+revision = "f0e8d3a4c612"
+down_revision = "e7c195a8b340"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # ---- Translations: move uniqueness from word pair to sense pair ----
+    with op.batch_alter_table("translations", schema=None) as batch_op:
+        batch_op.drop_constraint("unique_translation_pair", type_="unique")
+    with op.batch_alter_table("translations", schema=None) as batch_op:
+        batch_op.create_unique_constraint(
+            "unique_translation_sense_pair",
+            ["source_sense_id", "target_sense_id"],
+        )
+        batch_op.create_index(
+            "idx_translations_source_word_id",
+            ["source_word_id"],
+            unique=False,
+        )
+
+    # ---- DailyWord: drop uniqueness on translation_id ----
+    # SQLite stored the unique=True column as a constraint named
+    # "daily_words_translation_id_key" or similar via SQLAlchemy. To handle
+    # both the SQLAlchemy-default name and the Postgres-default name
+    # portably, drop via batch_alter_table.alter_column with unique=False.
+    with op.batch_alter_table("daily_words", schema=None) as batch_op:
+        batch_op.drop_constraint(
+            "unique_daily_words_translation_id", type_="unique"
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("daily_words", schema=None) as batch_op:
+        batch_op.create_unique_constraint(
+            "unique_daily_words_translation_id",
+            ["translation_id"],
+        )
+
+    with op.batch_alter_table("translations", schema=None) as batch_op:
+        batch_op.drop_index("idx_translations_source_word_id")
+        batch_op.drop_constraint(
+            "unique_translation_sense_pair", type_="unique"
+        )
+    with op.batch_alter_table("translations", schema=None) as batch_op:
+        batch_op.create_unique_constraint(
+            "unique_translation_pair",
+            ["source_word_id", "target_word_id"],
+        )

--- a/alarino_backend/migrations/versions/f6a182cd9e07_phase5_dailyword_translation_id.py
+++ b/alarino_backend/migrations/versions/f6a182cd9e07_phase5_dailyword_translation_id.py
@@ -1,0 +1,184 @@
+"""phase 5: normalize DailyWord to reference Translation
+
+Revision ID: f6a182cd9e07
+Revises: e5a9c2b48d76
+Create Date: 2026-04-25
+
+Implements Phase 5 of the schema evolution plan
+(docs/plans/schema_evolution_plan.md).
+
+Replaces DailyWord.word_id + DailyWord.en_word_id (two independent FKs to
+words, with no schema-level guarantee that the two words actually form a
+translation pair) with a single DailyWord.translation_id FK to translations.
+
+Phase 4 settled on directed storage with bidirectional lookup, so the
+backfill must look for the matching Translation row in BOTH directions
+(word_id, en_word_id) and (en_word_id, word_id) — either is a valid match.
+
+OPERATOR PREFLIGHT (production):
+    The migration aborts with a list of offending dw_id values if any
+    DailyWord row has no matching Translation in either direction.
+    Surface this in staging first; the offending rows are corrupt data
+    (a daily word that points at two unrelated Words) and must be
+    reconciled manually before production. Two reconciliation paths:
+        a) Delete the bad daily_words row.
+        b) Insert the intended translation pair manually into translations,
+           then re-run the migration.
+    Do NOT silently auto-create a translation here — that would launder
+    the corruption into accepted curated data.
+
+REVERSIBILITY:
+    Forward path makes a destructive column drop (word_id, en_word_id).
+    Downgrade re-adds the columns and backfills them from the linked
+    translation, recovering the same bytes that were dropped — but only
+    when the backfill was clean (every daily_words row had a matching
+    translation). This is reversible WITHOUT the data-loss opt-in escape
+    hatch other phases use, because the data is recoverable from the
+    referenced Translation.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "f6a182cd9e07"
+down_revision = "e5a9c2b48d76"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # ---- Step 1: add translation_id, nullable initially so the backfill can run ----
+    with op.batch_alter_table("daily_words", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "translation_id",
+                sa.Integer(),
+                sa.ForeignKey(
+                    "translations.t_id",
+                    name="fk_daily_words_translation_id",
+                    ondelete="CASCADE",
+                ),
+                nullable=True,
+            )
+        )
+
+    # ---- Step 2: backfill translation_id from existing word_id + en_word_id ----
+    connection = op.get_bind()
+    daily_rows = connection.execute(
+        sa.text("SELECT dw_id, word_id, en_word_id FROM daily_words")
+    ).fetchall()
+
+    unmatched: list[int] = []
+    for dw_id, word_id, en_word_id in daily_rows:
+        # Phase 4 stores translations as directed edges; check both possible
+        # directions for the matching pair.
+        match = connection.execute(
+            sa.text(
+                "SELECT t_id FROM translations "
+                "WHERE (source_word_id = :a AND target_word_id = :b) "
+                "OR (source_word_id = :b AND target_word_id = :a) "
+                "ORDER BY t_id LIMIT 1"
+            ),
+            {"a": word_id, "b": en_word_id},
+        ).fetchone()
+        if match is None:
+            unmatched.append(dw_id)
+            continue
+        connection.execute(
+            sa.text(
+                "UPDATE daily_words SET translation_id = :t WHERE dw_id = :d"
+            ),
+            {"t": match[0], "d": dw_id},
+        )
+
+    if unmatched:
+        raise RuntimeError(
+            "Phase 5 (revision f6a182cd9e07) cannot proceed: the following "
+            f"daily_words rows have no matching translation in either direction: {unmatched}. "
+            "These are corrupt: a daily word that points at two unrelated Words. "
+            "Reconcile by either deleting the bad daily_words rows or inserting "
+            "the intended translation pair manually into translations, then "
+            "re-run the migration. Do NOT auto-create a translation here — "
+            "that would launder the corruption into accepted curated data."
+        )
+
+    # ---- Step 3: tighten translation_id, add unique constraint, drop old columns ----
+    with op.batch_alter_table("daily_words", schema=None) as batch_op:
+        batch_op.alter_column(
+            "translation_id",
+            existing_type=sa.Integer(),
+            nullable=False,
+        )
+        batch_op.create_unique_constraint(
+            "unique_daily_words_translation_id",
+            ["translation_id"],
+        )
+        batch_op.drop_column("en_word_id")
+        batch_op.drop_column("word_id")
+
+
+def downgrade():
+    # ---- Re-add word_id and en_word_id columns ----
+    with op.batch_alter_table("daily_words", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "word_id",
+                sa.Integer(),
+                sa.ForeignKey("words.w_id", name="fk_daily_words_word_id"),
+                nullable=True,
+            )
+        )
+        batch_op.add_column(
+            sa.Column(
+                "en_word_id",
+                sa.Integer(),
+                sa.ForeignKey(
+                    "words.w_id", name="fk_daily_words_en_word_id"
+                ),
+                nullable=True,
+            )
+        )
+
+    # ---- Backfill word_id and en_word_id from the linked translation. ----
+    # The original schema's word_id was conventionally the Yoruba side and
+    # en_word_id was the English side, derived from Word.language.
+    connection = op.get_bind()
+    rows = connection.execute(
+        sa.text(
+            "SELECT dw.dw_id, t.source_word_id, t.target_word_id, "
+            "       sw.language AS source_lang, tw.language AS target_lang "
+            "FROM daily_words dw "
+            "JOIN translations t ON t.t_id = dw.translation_id "
+            "JOIN words sw ON sw.w_id = t.source_word_id "
+            "JOIN words tw ON tw.w_id = t.target_word_id"
+        )
+    ).fetchall()
+    for dw_id, source_id, target_id, source_lang, target_lang in rows:
+        if source_lang == "yo":
+            yo_id, en_id = source_id, target_id
+        else:
+            yo_id, en_id = target_id, source_id
+        connection.execute(
+            sa.text(
+                "UPDATE daily_words SET word_id = :yo, en_word_id = :en "
+                "WHERE dw_id = :d"
+            ),
+            {"yo": yo_id, "en": en_id, "d": dw_id},
+        )
+
+    # ---- Tighten + drop translation_id ----
+    with op.batch_alter_table("daily_words", schema=None) as batch_op:
+        batch_op.alter_column(
+            "word_id",
+            existing_type=sa.Integer(),
+            nullable=False,
+        )
+        batch_op.alter_column(
+            "en_word_id",
+            existing_type=sa.Integer(),
+            nullable=False,
+        )
+        batch_op.drop_constraint(
+            "unique_daily_words_translation_id", type_="unique"
+        )
+        batch_op.drop_column("translation_id")

--- a/alarino_backend/pyproject.toml
+++ b/alarino_backend/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
   "pytest==8.3.4",
+  "pytest-cov==7.1.0",
 ]
 
 [tool.setuptools]

--- a/alarino_backend/src/alarino_backend/app.py
+++ b/alarino_backend/src/alarino_backend/app.py
@@ -72,7 +72,6 @@ def get_translation(text: str, source_language: Language, target_language: Langu
         text,
         source_language,
         target_language,
-        request.remote_addr,
         request.headers.get("User-Agent", "unknown"),
     )
 

--- a/alarino_backend/src/alarino_backend/data/generate_sitemap.py
+++ b/alarino_backend/src/alarino_backend/data/generate_sitemap.py
@@ -53,7 +53,7 @@ def generate_sitemap(output_path: str) -> None:
 
     # Add English word pages
     for word in english_words:
-        word_text = word.word.strip().lower()
+        word_text = word.text.strip().lower()
         if word_text and word_text not in processed_words:
             processed_words.add(word_text)
             # Create word-specific URL with proper encoding

--- a/alarino_backend/src/alarino_backend/data/seed_data_utils.py
+++ b/alarino_backend/src/alarino_backend/data/seed_data_utils.py
@@ -33,10 +33,10 @@ def add_word(language: Language, word_text: str):
         logger.debug(f"Invalid English word rejected: {word_text}")
         return None
 
-    existing_word = Word.query.filter_by(language=language, word=word_text).first()
+    existing_word = Word.query.filter_by(language=language, text=word_text).first()
     if existing_word:
         return existing_word
-    word = Word(language=language, word=word_text)
+    word = Word(language=language, text=word_text)
     db.session.add(word)
     return word
 

--- a/alarino_backend/src/alarino_backend/data/seed_data_utils.py
+++ b/alarino_backend/src/alarino_backend/data/seed_data_utils.py
@@ -2,10 +2,11 @@ import json
 import re
 import unicodedata
 from pathlib import Path
-from typing import Callable
+from typing import Callable, Optional
 
 from alarino_backend.db_models import Proverb, ProverbWord, Sense, db, Word, Translation
 from alarino_backend.languages import Language
+from alarino_backend.parts_of_speech import PartOfSpeech
 # normalize_word_text and normalize_text live in alarino_backend.normalization
 # so the TypeDecorators in db_models.py can use them without a circular import.
 # Re-exported here for callers that import them from this module.
@@ -19,7 +20,15 @@ _YORUBA_NASAL_VOWELS = "mḿm̀nńǹ"  # Nasal vowels with tone marks
 _YORUBA_CHARACTER_SET = _YORUBA_CONSONANTS + _YORUBA_VOWELS + _YORUBA_NASAL_VOWELS
 
 
-def add_word(language: Language, word_text: str, part_of_speech: str = None):
+def add_word(
+    language: Language,
+    word_text: str,
+    part_of_speech: Optional[PartOfSpeech] = None,
+):
+    """Insert a word, returning the existing row if (language, word) already
+    exists. ``part_of_speech`` must be a PartOfSpeech enum value or None;
+    arbitrary strings are no longer accepted (the DB-level
+    ck_words_part_of_speech_valid CHECK would reject them anyway)."""
     word_text = normalize_word_text(word_text)
 
     if language == Language.YORUBA and not is_valid_yoruba_word(word_text):
@@ -32,7 +41,8 @@ def add_word(language: Language, word_text: str, part_of_speech: str = None):
     existing_word = Word.query.filter_by(language=language, word=word_text).first()
     if existing_word:
         return existing_word
-    word = Word(language=language, word=word_text, part_of_speech=part_of_speech)
+    pos_value = part_of_speech.value if part_of_speech is not None else None
+    word = Word(language=language, word=word_text, part_of_speech=pos_value)
     db.session.add(word)
     return word
 

--- a/alarino_backend/src/alarino_backend/data/seed_data_utils.py
+++ b/alarino_backend/src/alarino_backend/data/seed_data_utils.py
@@ -6,6 +6,10 @@ from typing import Callable
 
 from alarino_backend.db_models import Proverb, ProverbWord, db, Word, Translation
 from alarino_backend.languages import Language
+# normalize_word_text and normalize_text live in alarino_backend.normalization
+# so the TypeDecorators in db_models.py can use them without a circular import.
+# Re-exported here for callers that import them from this module.
+from alarino_backend.normalization import normalize_text, normalize_word_text  # noqa: F401
 from alarino_backend.runtime import logger
 
 # Define valid Yoruba character sets
@@ -13,22 +17,6 @@ _YORUBA_CONSONANTS = "bdfghjklmnprstwygbṣ"  # Standard consonants (excluding c
 _YORUBA_VOWELS = "aàáeèéẹẹ̀ẹ́iìíoòóọọ̀ọ́uùú"  # Standard vowels with tone marks
 _YORUBA_NASAL_VOWELS = "mḿm̀nńǹ"  # Nasal vowels with tone marks
 _YORUBA_CHARACTER_SET = _YORUBA_CONSONANTS + _YORUBA_VOWELS + _YORUBA_NASAL_VOWELS
-
-
-def normalize_word_text(text: str) -> str:
-    """Canonical normalization for word lookups: strip surrounding whitespace
-    and punctuation, lowercase, then NFC. Storage and read paths must both go
-    through this so canonically-equivalent inputs (e.g., precomposed vs.
-    decomposed Yoruba diacritics) collapse to the same key."""
-    cleaned = text.strip().strip(" ,.?!()").lower()
-    return unicodedata.normalize("NFC", cleaned)
-
-
-def normalize_text(text: str) -> str:
-    """Canonical normalization for sentence/proverb-level text: strip leading
-    and trailing whitespace, then NFC. Case is preserved (proverbs may carry
-    intentional capitalization) and inner punctuation is preserved."""
-    return unicodedata.normalize("NFC", text.strip())
 
 
 def add_word(language: Language, word_text: str, part_of_speech: str = None):

--- a/alarino_backend/src/alarino_backend/data/seed_data_utils.py
+++ b/alarino_backend/src/alarino_backend/data/seed_data_utils.py
@@ -4,7 +4,7 @@ import unicodedata
 from pathlib import Path
 from typing import Callable
 
-from alarino_backend.db_models import Proverb, ProverbWord, db, Word, Translation
+from alarino_backend.db_models import Proverb, ProverbWord, Sense, db, Word, Translation
 from alarino_backend.languages import Language
 # normalize_word_text and normalize_text live in alarino_backend.normalization
 # so the TypeDecorators in db_models.py can use them without a circular import.
@@ -169,6 +169,34 @@ def is_valid_english_text(text: str) -> bool:
     pattern = r"^[a-z' .,?!;:-]+$"
     return bool(re.match(pattern, text, re.UNICODE))
 
+def _ensure_default_sense(word: Word) -> Sense:
+    """Return a sense for the word, creating a default one if none exist.
+
+    Phase 6b ensures every Translation has non-NULL source_sense_id and
+    target_sense_id. The bulk-upload write path doesn't carry sense-level
+    information today (the input format is just word→word pairs), so we
+    default to the first sense if one exists, otherwise create one carrying
+    the word's part_of_speech. Polysemy — multiple senses per word with
+    distinct labels/definitions — is supported by the schema and will be
+    populated by an explicit admin curation flow in a later feature.
+    """
+    word.w_id  # ensure attribute is loaded; flush if needed
+    if word.w_id is None:
+        db.session.flush()
+    existing = (
+        Sense.query
+        .filter_by(word_id=word.w_id)
+        .order_by(Sense.sense_id)
+        .first()
+    )
+    if existing is not None:
+        return existing
+    sense = Sense(word_id=word.w_id, part_of_speech=word.part_of_speech)
+    db.session.add(sense)
+    db.session.flush()
+    return sense
+
+
 def create_translation(source: Word, target: Word):
     existing = Translation.query.filter_by(
         source_word_id=source.w_id,
@@ -176,7 +204,14 @@ def create_translation(source: Word, target: Word):
     ).first()
     if existing:
         return
-    translation = Translation(source_word=source, target_word=target)
+    source_sense = _ensure_default_sense(source)
+    target_sense = _ensure_default_sense(target)
+    translation = Translation(
+        source_word=source,
+        target_word=target,
+        source_sense_id=source_sense.sense_id,
+        target_sense_id=target_sense.sense_id,
+    )
     db.session.add(translation)
 
 

--- a/alarino_backend/src/alarino_backend/data/seed_data_utils.py
+++ b/alarino_backend/src/alarino_backend/data/seed_data_utils.py
@@ -4,7 +4,7 @@ import unicodedata
 from pathlib import Path
 from typing import Callable
 
-from alarino_backend.db_models import Proverb, db, Word, Translation
+from alarino_backend.db_models import Proverb, ProverbWord, db, Word, Translation
 from alarino_backend.languages import Language
 from alarino_backend.runtime import logger
 
@@ -15,9 +15,24 @@ _YORUBA_NASAL_VOWELS = "mḿm̀nńǹ"  # Nasal vowels with tone marks
 _YORUBA_CHARACTER_SET = _YORUBA_CONSONANTS + _YORUBA_VOWELS + _YORUBA_NASAL_VOWELS
 
 
+def normalize_word_text(text: str) -> str:
+    """Canonical normalization for word lookups: strip surrounding whitespace
+    and punctuation, lowercase, then NFC. Storage and read paths must both go
+    through this so canonically-equivalent inputs (e.g., precomposed vs.
+    decomposed Yoruba diacritics) collapse to the same key."""
+    cleaned = text.strip().strip(" ,.?!()").lower()
+    return unicodedata.normalize("NFC", cleaned)
+
+
+def normalize_text(text: str) -> str:
+    """Canonical normalization for sentence/proverb-level text: strip leading
+    and trailing whitespace, then NFC. Case is preserved (proverbs may carry
+    intentional capitalization) and inner punctuation is preserved."""
+    return unicodedata.normalize("NFC", text.strip())
+
+
 def add_word(language: Language, word_text: str, part_of_speech: str = None):
-    word_text = word_text.strip().strip(" ,.?!()").lower()
-    word_text = unicodedata.normalize('NFC', word_text)
+    word_text = normalize_word_text(word_text)
 
     if language == Language.YORUBA and not is_valid_yoruba_word(word_text):
         logger.debug(f"Invalid Yoruba word rejected: {word_text}")
@@ -42,6 +57,12 @@ def add_proverb(yoruba_proverb: str, english_proverb: str):
         yoruba_proverb: The Yoruba version of the proverb.
         english_proverb: The English version of the proverb.
     """
+    # Normalize text-level inputs to NFC before any storage or comparison so
+    # canonically-equivalent forms (precomposed vs decomposed Yoruba) collide
+    # at the unique constraint and at duplicate detection.
+    yoruba_proverb = normalize_text(yoruba_proverb)
+    english_proverb = normalize_text(english_proverb)
+
     # Check if the proverb already exists
     existing_proverb = Proverb.query.filter_by(
         yoruba_text=yoruba_proverb,
@@ -55,17 +76,31 @@ def add_proverb(yoruba_proverb: str, english_proverb: str):
     # Add the new proverb
     new_proverb = Proverb(yoruba_text=yoruba_proverb, english_text=english_proverb)
     db.session.add(new_proverb)
+    db.session.flush()  # Need new_proverb.p_id to populate proverb_words.
     logger.info(f"Added proverb: '{yoruba_proverb}'")
 
-    # Extract and add individual words
-    yoruba_words = re.findall(r'\b\w+\b', yoruba_proverb)
-    english_words = re.findall(r'\b\w+\b', english_proverb)
-
-    for word in yoruba_words:
-        add_word(language=Language.YORUBA, word_text=word)
-
-    for word in english_words:
-        add_word(language=Language.ENGLISH, word_text=word)
+    # Extract individual words and connect them to the proverb via proverb_words.
+    # Words that fail validation (add_word returns None) are silently skipped — the
+    # proverb itself is still stored, only the join entry is missing.
+    for language, raw_text in (
+        (Language.YORUBA, yoruba_proverb),
+        (Language.ENGLISH, english_proverb),
+    ):
+        position = 0
+        for token in re.findall(r'\b\w+\b', raw_text):
+            word = add_word(language=language, word_text=token)
+            if word is None:
+                continue
+            db.session.flush()  # Need word.w_id if add_word inserted a new row.
+            db.session.add(
+                ProverbWord(
+                    proverb_id=new_proverb.p_id,
+                    word_id=word.w_id,
+                    language=language.value,
+                    position=position,
+                )
+            )
+            position += 1
 
 
 def _is_valid_yoruba(text: str, extra_chars: str) -> bool:
@@ -79,7 +114,10 @@ def _is_valid_yoruba(text: str, extra_chars: str) -> bool:
     """
     if not text:
         return False
-    text = text.strip().lower()
+    # Normalize input to NFC so the codepoints align with the (NFC) char class
+    # below. Without this, NFD input that is canonically valid Yoruba would be
+    # rejected because its decomposed codepoints don't appear in the char set.
+    text = unicodedata.normalize('NFC', text.strip().lower())
     valid_chars = unicodedata.normalize('NFC', _YORUBA_CHARACTER_SET + extra_chars)
     escaped_chars = re.escape(valid_chars)
     pattern = f"^[{escaped_chars}]+$"
@@ -116,7 +154,10 @@ def is_valid_english_word(word: str) -> bool:
     Returns:
         bool: Whether the word contains only valid English characters
     """
-    word = word.strip().lower()
+    # NFC normalize for consistency with the Yoruba validators. ASCII is
+    # invariant under NFC/NFD, so this is a no-op for ASCII input but ensures
+    # any stray combining marks in input are handled the same way storage does.
+    word = unicodedata.normalize("NFC", word.strip().lower())
     if not word:
         return False
 
@@ -132,7 +173,7 @@ def is_valid_english_text(text: str) -> bool:
     Returns:
         bool: Whether the text is valid.
     """
-    text = text.strip().lower()
+    text = unicodedata.normalize("NFC", text.strip().lower())
     if not text:
         return False
 

--- a/alarino_backend/src/alarino_backend/data/seed_data_utils.py
+++ b/alarino_backend/src/alarino_backend/data/seed_data_utils.py
@@ -173,28 +173,42 @@ def is_valid_english_text(text: str) -> bool:
     pattern = r"^[a-z' .,?!;:-]+$"
     return bool(re.match(pattern, text, re.UNICODE))
 
-def _ensure_default_sense(word: Word) -> Sense:
-    """Return a sense for the word, creating a default one if none exist.
+class AmbiguousSenseError(ValueError):
+    """Raised when a write path that doesn't specify a sense is asked to
+    operate on a word that has more than one curated sense. The caller must
+    either pick a sense explicitly or fall back to a sense-aware API."""
 
-    Phase 6b ensures every Translation has non-NULL source_sense_id and
-    target_sense_id. The bulk-upload write path doesn't carry sense-level
-    information today (the input format is just word→word pairs), so we
-    default to the first sense if one exists, otherwise create one carrying
-    the word's part_of_speech. Polysemy — multiple senses per word with
-    distinct labels/definitions — is supported by the schema and will be
-    populated by an explicit admin curation flow in a later feature.
+
+def _ensure_default_sense(word: Word) -> Sense:
+    """Return THE sense for the word, creating a default one if none exist.
+
+    Strict: if the word already has multiple senses, this raises
+    AmbiguousSenseError. Bulk-upload and similar write paths that carry no
+    sense information would otherwise silently bind a new translation to
+    whichever sense has the lowest sense_id — an arbitrary choice that
+    almost certainly doesn't match curator intent. Failing loud forces
+    the caller to use a sense-aware path (or for the curator to deduplicate
+    senses on the word) before the silent corruption can land.
     """
     word.w_id  # ensure attribute is loaded; flush if needed
     if word.w_id is None:
         db.session.flush()
-    existing = (
+    senses = (
         Sense.query
         .filter_by(word_id=word.w_id)
         .order_by(Sense.sense_id)
-        .first()
+        .all()
     )
-    if existing is not None:
-        return existing
+    if len(senses) > 1:
+        labels = [(s.sense_id, s.sense_label) for s in senses]
+        raise AmbiguousSenseError(
+            f"Word w_id={word.w_id} ({word.language}:{word.text!r}) has "
+            f"{len(senses)} senses {labels!r}; cannot pick a default. "
+            "Use a sense-aware API to specify which sense the new "
+            "translation should attach to."
+        )
+    if senses:
+        return senses[0]
     # Default sense carries no POS metadata. Phase 6d removed the
     # Word.part_of_speech column that this previously copied; callers who
     # want POS set it on the Sense explicitly via a future curation flow.
@@ -205,14 +219,24 @@ def _ensure_default_sense(word: Word) -> Sense:
 
 
 def create_translation(source: Word, target: Word):
+    """Create a Translation between two Words, attaching to each Word's
+    default sense. Raises AmbiguousSenseError if either word has multiple
+    curated senses (the bulk-upload format carries no sense info; binding
+    to whichever sense_id is lowest would silently corrupt curator intent).
+
+    Idempotent on the (source_sense, target_sense) pair: if a Translation
+    already exists with the resolved sense pair, this is a no-op. Polysemy
+    that targets the same surface words via *different* sense pairs is
+    representable — that's exactly what the unique_translation_sense_pair
+    constraint allows."""
+    source_sense = _ensure_default_sense(source)
+    target_sense = _ensure_default_sense(target)
     existing = Translation.query.filter_by(
-        source_word_id=source.w_id,
-        target_word_id=target.w_id
+        source_sense_id=source_sense.sense_id,
+        target_sense_id=target_sense.sense_id,
     ).first()
     if existing:
         return
-    source_sense = _ensure_default_sense(source)
-    target_sense = _ensure_default_sense(target)
     translation = Translation(
         source_word=source,
         target_word=target,

--- a/alarino_backend/src/alarino_backend/data/seed_data_utils.py
+++ b/alarino_backend/src/alarino_backend/data/seed_data_utils.py
@@ -2,11 +2,10 @@ import json
 import re
 import unicodedata
 from pathlib import Path
-from typing import Callable, Optional
+from typing import Callable
 
 from alarino_backend.db_models import Proverb, ProverbWord, Sense, db, Word, Translation
 from alarino_backend.languages import Language
-from alarino_backend.parts_of_speech import PartOfSpeech
 # normalize_word_text and normalize_text live in alarino_backend.normalization
 # so the TypeDecorators in db_models.py can use them without a circular import.
 # Re-exported here for callers that import them from this module.
@@ -20,15 +19,11 @@ _YORUBA_NASAL_VOWELS = "mḿm̀nńǹ"  # Nasal vowels with tone marks
 _YORUBA_CHARACTER_SET = _YORUBA_CONSONANTS + _YORUBA_VOWELS + _YORUBA_NASAL_VOWELS
 
 
-def add_word(
-    language: Language,
-    word_text: str,
-    part_of_speech: Optional[PartOfSpeech] = None,
-):
+def add_word(language: Language, word_text: str):
     """Insert a word, returning the existing row if (language, word) already
-    exists. ``part_of_speech`` must be a PartOfSpeech enum value or None;
-    arbitrary strings are no longer accepted (the DB-level
-    ck_words_part_of_speech_valid CHECK would reject them anyway)."""
+    exists. POS is no longer a Word-level attribute (Phase 6d dropped
+    Word.part_of_speech) — to attach POS, set it on a Sense for this Word
+    after creation."""
     word_text = normalize_word_text(word_text)
 
     if language == Language.YORUBA and not is_valid_yoruba_word(word_text):
@@ -41,8 +36,7 @@ def add_word(
     existing_word = Word.query.filter_by(language=language, word=word_text).first()
     if existing_word:
         return existing_word
-    pos_value = part_of_speech.value if part_of_speech is not None else None
-    word = Word(language=language, word=word_text, part_of_speech=pos_value)
+    word = Word(language=language, word=word_text)
     db.session.add(word)
     return word
 
@@ -201,7 +195,10 @@ def _ensure_default_sense(word: Word) -> Sense:
     )
     if existing is not None:
         return existing
-    sense = Sense(word_id=word.w_id, part_of_speech=word.part_of_speech)
+    # Default sense carries no POS metadata. Phase 6d removed the
+    # Word.part_of_speech column that this previously copied; callers who
+    # want POS set it on the Sense explicitly via a future curation flow.
+    sense = Sense(word_id=word.w_id)
     db.session.add(sense)
     db.session.flush()
     return sense

--- a/alarino_backend/src/alarino_backend/db_models.py
+++ b/alarino_backend/src/alarino_backend/db_models.py
@@ -51,7 +51,9 @@ class Word(db.Model):
     w_id = db.Column(db.Integer, primary_key=True)
     language = db.Column(db.String(3), nullable=False)
     word = db.Column(NFCWord(200), nullable=False)  ##todo: rename to text
-    part_of_speech = db.Column(db.String(20))
+    # Phase 6d removed Word.part_of_speech. POS is now a sense-level attribute
+    # only — a polysemous word can carry distinct POS values per sense (e.g.,
+    # "run" as both noun and verb). Set Sense.part_of_speech instead.
     created_at = db.Column(
         db.DateTime,
         nullable=False,
@@ -65,10 +67,6 @@ class Word(db.Model):
             "language IN ('en', 'yo')",
             name='ck_words_language_valid',
         ),
-        db.CheckConstraint(
-            _POS_CHECK_CLAUSE,
-            name='ck_words_part_of_speech_valid',
-        ),
     )
 
     def __repr__(self):
@@ -81,20 +79,18 @@ class Translation(db.Model):
     t_id = db.Column(db.Integer, primary_key=True)
     source_word_id = db.Column(db.Integer, db.ForeignKey('words.w_id', ondelete='CASCADE'), nullable=False)
     target_word_id = db.Column(db.Integer, db.ForeignKey('words.w_id', ondelete='CASCADE'), nullable=False)
-    # Phase 6a additions: senses are between Word and Translation. These FKs
-    # are nullable in 6a (backfilled from one-sense-per-word during the
-    # migration) and become NOT NULL in 6d after the cutover. Read paths in
-    # 6c will use these to group polysemous matches; write paths in 6b will
-    # require them on every new Translation.
+    # Phase 6a added these FKs nullable; Phase 6b cut writes over to populate
+    # them on every new Translation; Phase 6d makes them NOT NULL now that
+    # every existing row is backfilled and every new row sets them.
     source_sense_id = db.Column(
         db.Integer,
         db.ForeignKey('senses.sense_id', name='fk_translations_source_sense_id', ondelete='CASCADE'),
-        nullable=True,
+        nullable=False,
     )
     target_sense_id = db.Column(
         db.Integer,
         db.ForeignKey('senses.sense_id', name='fk_translations_target_sense_id', ondelete='CASCADE'),
-        nullable=True,
+        nullable=False,
     )
     note = db.Column(db.Text, nullable=True)
     confidence = db.Column(db.Float, nullable=True)
@@ -131,9 +127,9 @@ class Sense(db.Model):
         db.ForeignKey('words.w_id', ondelete='CASCADE'),
         nullable=False,
     )
-    # part_of_speech is duplicated on Word during Phases 6a-6c (read paths still
-    # use Word.part_of_speech). The Word column is dropped in Phase 6d once the
-    # sense layer is fully load-bearing.
+    # Phase 6d removed Word.part_of_speech. Sense.part_of_speech is now the
+    # only place POS lives. Polysemous words can carry distinct POS values
+    # per sense.
     part_of_speech = db.Column(db.String(20), nullable=True)
     sense_label = db.Column(db.String(80), nullable=True)
     definition = db.Column(db.Text, nullable=True)
@@ -237,12 +233,11 @@ class Example(db.Model):
     __tablename__ = 'examples'
 
     e_id = db.Column(db.Integer, primary_key=True)
-    translation_id = db.Column(db.Integer, db.ForeignKey('translations.t_id', ondelete='CASCADE'), nullable=False)
-    # Phase 6b additions: examples are sense-scoped, not just translation-scoped
-    # (an example for "bank — financial institution" shouldn't appear under
-    # "bank — riverbank"). Nullable here in 6b so the backfill can run
-    # incrementally; tightened in 6d. translation_id is intentionally kept
-    # until 6d so the existing relationship and read path keep working.
+    # Phase 6d dropped translation_id. Examples are now sense-pair-scoped
+    # only — the (source_sense_id, target_sense_id) pair identifies which
+    # translation the example belongs to. Sense FKs stay nullable in 6d
+    # because Example creation paths don't yet exist in app code; future
+    # callers must set them explicitly to make the example queryable.
     source_sense_id = db.Column(
         db.Integer,
         db.ForeignKey('senses.sense_id', name='fk_examples_source_sense_id', ondelete='CASCADE'),
@@ -262,21 +257,21 @@ class Example(db.Model):
         server_default=func.now(),
     )
 
-    translation = db.relationship('Translation', backref='examples')
     source_sense = db.relationship('Sense', foreign_keys=[source_sense_id])
     target_sense = db.relationship('Sense', foreign_keys=[target_sense_id])
 
     __table_args__ = (
         db.UniqueConstraint(
-            'translation_id',
+            'source_sense_id',
+            'target_sense_id',
             'example_source',
             'example_target',
-            name='unique_example_per_translation',
+            name='unique_example_per_sense_pair',
         ),
     )
 
     def __repr__(self):
-        return f"<Example for Translation {self.translation_id}>"
+        return f"<Example sense_pair=({self.source_sense_id}, {self.target_sense_id})>"
 
 
 class Proverb(db.Model):

--- a/alarino_backend/src/alarino_backend/db_models.py
+++ b/alarino_backend/src/alarino_backend/db_models.py
@@ -112,9 +112,17 @@ class Translation(db.Model):
     target_sense = db.relationship('Sense', foreign_keys=[target_sense_id])
 
     __table_args__ = (
-        db.UniqueConstraint('source_word_id', 'target_word_id', name='unique_translation_pair'),
-        # target_word_id index supports reverse-direction joins; source_word_id
-        # is already covered by the unique_translation_pair constraint prefix.
+        # Uniqueness is on the SENSE pair, not the WORD pair, so polysemy can
+        # express two distinct (source_sense, target_sense) translations even
+        # when they happen to involve the same surface words. See Phase 7
+        # bug-fix migration f0e8d3a4c612 for the rationale.
+        db.UniqueConstraint(
+            'source_sense_id', 'target_sense_id',
+            name='unique_translation_sense_pair',
+        ),
+        # Both word_id columns are indexed for the bidirectional translate()
+        # join; without an index on source_word_id, that side scans.
+        Index('idx_translations_source_word_id', 'source_word_id'),
         Index('idx_translations_target_word_id', 'target_word_id'),
     )
 
@@ -173,7 +181,12 @@ class DailyWord(db.Model):
         db.Integer,
         db.ForeignKey('translations.t_id', ondelete='CASCADE'),
         nullable=False,
-        unique=True,
+        # NOT unique — a translation can legitimately recur as the daily word
+        # on different dates. The original Phase 5 design had unique=True but
+        # that conflicted with find_random_unused_translation's default
+        # can_reuse=True path, causing 500s when an already-seen translation
+        # was picked. Date uniqueness (one daily word per date) is enforced
+        # via the date column. See Phase 7 bug-fix migration f0e8d3a4c612.
     )
     date = db.Column(db.Date, default=date.today, unique=True)
     created_at = db.Column(

--- a/alarino_backend/src/alarino_backend/db_models.py
+++ b/alarino_backend/src/alarino_backend/db_models.py
@@ -5,6 +5,14 @@ from sqlalchemy.types import TypeDecorator
 
 from alarino_backend.flask_extensions import db
 from alarino_backend.normalization import normalize_text, normalize_word_text
+from alarino_backend.parts_of_speech import ALLOWED_POS_VALUES
+
+
+_POS_CHECK_CLAUSE = (
+    "part_of_speech IS NULL OR part_of_speech IN ("
+    + ", ".join(f"'{v}'" for v in ALLOWED_POS_VALUES)
+    + ")"
+)
 
 
 class NFCWord(TypeDecorator):
@@ -56,6 +64,10 @@ class Word(db.Model):
         db.CheckConstraint(
             "language IN ('en', 'yo')",
             name='ck_words_language_valid',
+        ),
+        db.CheckConstraint(
+            _POS_CHECK_CLAUSE,
+            name='ck_words_part_of_speech_valid',
         ),
     )
 
@@ -138,6 +150,10 @@ class Sense(db.Model):
 
     __table_args__ = (
         Index('idx_senses_word_id', 'word_id'),
+        db.CheckConstraint(
+            _POS_CHECK_CLAUSE,
+            name='ck_senses_part_of_speech_valid',
+        ),
     )
 
     def __repr__(self):

--- a/alarino_backend/src/alarino_backend/db_models.py
+++ b/alarino_backend/src/alarino_backend/db_models.py
@@ -222,6 +222,21 @@ class Example(db.Model):
 
     e_id = db.Column(db.Integer, primary_key=True)
     translation_id = db.Column(db.Integer, db.ForeignKey('translations.t_id', ondelete='CASCADE'), nullable=False)
+    # Phase 6b additions: examples are sense-scoped, not just translation-scoped
+    # (an example for "bank — financial institution" shouldn't appear under
+    # "bank — riverbank"). Nullable here in 6b so the backfill can run
+    # incrementally; tightened in 6d. translation_id is intentionally kept
+    # until 6d so the existing relationship and read path keep working.
+    source_sense_id = db.Column(
+        db.Integer,
+        db.ForeignKey('senses.sense_id', name='fk_examples_source_sense_id', ondelete='CASCADE'),
+        nullable=True,
+    )
+    target_sense_id = db.Column(
+        db.Integer,
+        db.ForeignKey('senses.sense_id', name='fk_examples_target_sense_id', ondelete='CASCADE'),
+        nullable=True,
+    )
     example_source = db.Column(db.Text, nullable=False)
     example_target = db.Column(db.Text, nullable=False)
     created_at = db.Column(
@@ -232,6 +247,8 @@ class Example(db.Model):
     )
 
     translation = db.relationship('Translation', backref='examples')
+    source_sense = db.relationship('Sense', foreign_keys=[source_sense_id])
+    target_sense = db.relationship('Sense', foreign_keys=[target_sense_id])
 
     __table_args__ = (
         db.UniqueConstraint(

--- a/alarino_backend/src/alarino_backend/db_models.py
+++ b/alarino_backend/src/alarino_backend/db_models.py
@@ -94,8 +94,17 @@ class DailyWord(db.Model):
     __tablename__ = "daily_words"
 
     dw_id = db.Column(db.Integer, primary_key=True)
-    word_id = db.Column(db.Integer, db.ForeignKey("words.w_id"), nullable=False)
-    en_word_id = db.Column(db.Integer, db.ForeignKey("words.w_id"), nullable=False)
+    # Phase 5: replaces word_id + en_word_id with a single FK to the translation
+    # pair. Makes "daily word is a translation pair" a structural fact instead
+    # of a conventional pairing of two unrelated word_id columns. Read paths
+    # derive the Yoruba and English sides by joining Word and inspecting
+    # Word.language — never by assuming a column position.
+    translation_id = db.Column(
+        db.Integer,
+        db.ForeignKey('translations.t_id', ondelete='CASCADE'),
+        nullable=False,
+        unique=True,
+    )
     date = db.Column(db.Date, default=date.today, unique=True)
     created_at = db.Column(
         db.DateTime,
@@ -104,8 +113,7 @@ class DailyWord(db.Model):
         server_default=func.now(),
     )
 
-    word = db.relationship("Word", foreign_keys=[word_id])
-    en_word = db.relationship("Word", foreign_keys=[en_word_id])
+    translation = db.relationship("Translation")
 
     __table_args__ = (
         # Add index on date for faster lookups of daily words
@@ -113,7 +121,7 @@ class DailyWord(db.Model):
     )
 
     def __repr__(self):
-        return f"<DailyWord {self.word.word} for {self.date}>"
+        return f"<DailyWord translation_id={self.translation_id} for {self.date}>"
 
 
 class MissingTranslation(db.Model):

--- a/alarino_backend/src/alarino_backend/db_models.py
+++ b/alarino_backend/src/alarino_backend/db_models.py
@@ -50,7 +50,11 @@ class Word(db.Model):
 
     w_id = db.Column(db.Integer, primary_key=True)
     language = db.Column(db.String(3), nullable=False)
-    word = db.Column(NFCWord(200), nullable=False)  ##todo: rename to text
+    # Phase 7 renamed this column from `word` to `text`. The class is still
+    # named Word (it represents a word as a vocabulary entry); only the
+    # column holding the lexical string was renamed for clarity, since
+    # `word.word` was awkward and `word.text` reads naturally.
+    text = db.Column(NFCWord(200), nullable=False)
     # Phase 6d removed Word.part_of_speech. POS is now a sense-level attribute
     # only — a polysemous word can carry distinct POS values per sense (e.g.,
     # "run" as both noun and verb). Set Sense.part_of_speech instead.
@@ -62,7 +66,7 @@ class Word(db.Model):
     )
 
     __table_args__ = (
-        db.UniqueConstraint('language', 'word', name='unique_language_word'),
+        db.UniqueConstraint('language', 'text', name='unique_language_text'),
         db.CheckConstraint(
             "language IN ('en', 'yo')",
             name='ck_words_language_valid',
@@ -70,7 +74,7 @@ class Word(db.Model):
     )
 
     def __repr__(self):
-        return f"<Word {self.language}:{self.word}>"
+        return f"<Word {self.language}:{self.text}>"
 
 
 class Translation(db.Model):
@@ -115,7 +119,7 @@ class Translation(db.Model):
     )
 
     def __repr__(self):
-        return f"<Translation {self.source_word.word} -> {self.target_word.word}>"
+        return f"<Translation {self.source_word.text} -> {self.target_word.text}>"
 
 
 class Sense(db.Model):

--- a/alarino_backend/src/alarino_backend/db_models.py
+++ b/alarino_backend/src/alarino_backend/db_models.py
@@ -10,7 +10,7 @@ class Word(db.Model):
     language = db.Column(db.String(3), nullable=False)
     word = db.Column(db.String(200), nullable=False)  ##todo: rename to text
     part_of_speech = db.Column(db.String(20))
-    created_at = db.Column(db.DateTime, default=datetime.now())
+    created_at = db.Column(db.DateTime, default=datetime.now)
 
     __table_args__ = (
         db.UniqueConstraint('language', 'word', name='unique_language_word'),

--- a/alarino_backend/src/alarino_backend/db_models.py
+++ b/alarino_backend/src/alarino_backend/db_models.py
@@ -20,6 +20,10 @@ class Word(db.Model):
 
     __table_args__ = (
         db.UniqueConstraint('language', 'word', name='unique_language_word'),
+        db.CheckConstraint(
+            "language IN ('en', 'yo')",
+            name='ck_words_language_valid',
+        ),
     )
 
     def __repr__(self):
@@ -86,7 +90,6 @@ class MissingTranslation(db.Model):
     text = db.Column(db.String(200), nullable=False)
     source_language = db.Column(db.String(3), nullable=False)
     target_language = db.Column(db.String(3), nullable=False)
-    user_ip = db.Column(db.String(45))
     user_agent = db.Column(db.Text)
     hit_count = db.Column(
         db.Integer,
@@ -103,6 +106,14 @@ class MissingTranslation(db.Model):
 
     __table_args__ = (
         db.UniqueConstraint('text', 'source_language', 'target_language', name='unique_missing_translation'),
+        db.CheckConstraint(
+            "source_language IN ('en', 'yo')",
+            name='ck_missing_translations_source_language_valid',
+        ),
+        db.CheckConstraint(
+            "target_language IN ('en', 'yo')",
+            name='ck_missing_translations_target_language_valid',
+        ),
         # Add index on hit_count to quickly find most requested missing translations
         Index('idx_missing_hit_count', 'hit_count', postgresql_ops={'hit_count': 'DESC'}),
     )
@@ -159,3 +170,40 @@ class Proverb(db.Model):
 
     def __repr__(self):
         return f"<Proverb Yoruba: '{self.yoruba_text}' English: '{self.english_text}'>"
+
+
+class ProverbWord(db.Model):
+    __tablename__ = 'proverb_words'
+
+    proverb_id = db.Column(
+        db.Integer,
+        db.ForeignKey('proverbs.p_id', ondelete='CASCADE'),
+        primary_key=True,
+    )
+    word_id = db.Column(
+        db.Integer,
+        db.ForeignKey('words.w_id', ondelete='CASCADE'),
+        primary_key=True,
+    )
+    language = db.Column(db.String(3), primary_key=True)
+    # position is the 0-indexed order of the word within its language sequence
+    # in the proverb. Repeated occurrences of the same word get distinct
+    # position values so the composite PK stays unique.
+    position = db.Column(db.Integer, primary_key=True)
+
+    proverb = db.relationship('Proverb', backref='proverb_words')
+    word = db.relationship('Word')
+
+    __table_args__ = (
+        db.CheckConstraint(
+            "language IN ('en', 'yo')",
+            name='ck_proverb_words_language_valid',
+        ),
+        Index('idx_proverb_words_word_id', 'word_id'),
+    )
+
+    def __repr__(self):
+        return (
+            f"<ProverbWord proverb={self.proverb_id} word={self.word_id} "
+            f"lang={self.language} pos={self.position}>"
+        )

--- a/alarino_backend/src/alarino_backend/db_models.py
+++ b/alarino_backend/src/alarino_backend/db_models.py
@@ -69,6 +69,24 @@ class Translation(db.Model):
     t_id = db.Column(db.Integer, primary_key=True)
     source_word_id = db.Column(db.Integer, db.ForeignKey('words.w_id', ondelete='CASCADE'), nullable=False)
     target_word_id = db.Column(db.Integer, db.ForeignKey('words.w_id', ondelete='CASCADE'), nullable=False)
+    # Phase 6a additions: senses are between Word and Translation. These FKs
+    # are nullable in 6a (backfilled from one-sense-per-word during the
+    # migration) and become NOT NULL in 6d after the cutover. Read paths in
+    # 6c will use these to group polysemous matches; write paths in 6b will
+    # require them on every new Translation.
+    source_sense_id = db.Column(
+        db.Integer,
+        db.ForeignKey('senses.sense_id', name='fk_translations_source_sense_id', ondelete='CASCADE'),
+        nullable=True,
+    )
+    target_sense_id = db.Column(
+        db.Integer,
+        db.ForeignKey('senses.sense_id', name='fk_translations_target_sense_id', ondelete='CASCADE'),
+        nullable=True,
+    )
+    note = db.Column(db.Text, nullable=True)
+    confidence = db.Column(db.Float, nullable=True)
+    provenance = db.Column(db.String(40), nullable=True)
     created_at = db.Column(
         db.DateTime,
         nullable=False,
@@ -78,6 +96,8 @@ class Translation(db.Model):
 
     source_word = db.relationship('Word', foreign_keys=[source_word_id], backref='translations_from')
     target_word = db.relationship('Word', foreign_keys=[target_word_id], backref='translations_to')
+    source_sense = db.relationship('Sense', foreign_keys=[source_sense_id])
+    target_sense = db.relationship('Sense', foreign_keys=[target_sense_id])
 
     __table_args__ = (
         db.UniqueConstraint('source_word_id', 'target_word_id', name='unique_translation_pair'),
@@ -88,6 +108,40 @@ class Translation(db.Model):
 
     def __repr__(self):
         return f"<Translation {self.source_word.word} -> {self.target_word.word}>"
+
+
+class Sense(db.Model):
+    __tablename__ = 'senses'
+
+    sense_id = db.Column(db.Integer, primary_key=True)
+    word_id = db.Column(
+        db.Integer,
+        db.ForeignKey('words.w_id', ondelete='CASCADE'),
+        nullable=False,
+    )
+    # part_of_speech is duplicated on Word during Phases 6a-6c (read paths still
+    # use Word.part_of_speech). The Word column is dropped in Phase 6d once the
+    # sense layer is fully load-bearing.
+    part_of_speech = db.Column(db.String(20), nullable=True)
+    sense_label = db.Column(db.String(80), nullable=True)
+    definition = db.Column(db.Text, nullable=True)
+    register = db.Column(db.String(40), nullable=True)
+    domain = db.Column(db.String(80), nullable=True)
+    created_at = db.Column(
+        db.DateTime,
+        nullable=False,
+        default=datetime.now,
+        server_default=func.now(),
+    )
+
+    word = db.relationship('Word', backref='senses')
+
+    __table_args__ = (
+        Index('idx_senses_word_id', 'word_id'),
+    )
+
+    def __repr__(self):
+        return f"<Sense {self.sense_id} for word {self.word_id} label={self.sense_label!r}>"
 
 
 class DailyWord(db.Model):

--- a/alarino_backend/src/alarino_backend/db_models.py
+++ b/alarino_backend/src/alarino_backend/db_models.py
@@ -1,5 +1,6 @@
 from datetime import date, datetime
-from sqlalchemy import Index
+from sqlalchemy import Index, func
+from sqlalchemy import text as sql_text
 
 from alarino_backend.flask_extensions import db
 
@@ -10,14 +11,15 @@ class Word(db.Model):
     language = db.Column(db.String(3), nullable=False)
     word = db.Column(db.String(200), nullable=False)  ##todo: rename to text
     part_of_speech = db.Column(db.String(20))
-    created_at = db.Column(db.DateTime, default=datetime.now)
+    created_at = db.Column(
+        db.DateTime,
+        nullable=False,
+        default=datetime.now,
+        server_default=func.now(),
+    )
 
     __table_args__ = (
         db.UniqueConstraint('language', 'word', name='unique_language_word'),
-        # Add index on language and word for faster lookups
-        Index('idx_words_language_word', 'language', 'word'),
-        # Add index on just language for filtering words by language
-        Index('idx_words_language', 'language'),
     )
 
     def __repr__(self):
@@ -30,15 +32,20 @@ class Translation(db.Model):
     t_id = db.Column(db.Integer, primary_key=True)
     source_word_id = db.Column(db.Integer, db.ForeignKey('words.w_id', ondelete='CASCADE'), nullable=False)
     target_word_id = db.Column(db.Integer, db.ForeignKey('words.w_id', ondelete='CASCADE'), nullable=False)
-    created_at = db.Column(db.DateTime, default=datetime.now)
+    created_at = db.Column(
+        db.DateTime,
+        nullable=False,
+        default=datetime.now,
+        server_default=func.now(),
+    )
 
     source_word = db.relationship('Word', foreign_keys=[source_word_id], backref='translations_from')
     target_word = db.relationship('Word', foreign_keys=[target_word_id], backref='translations_to')
 
     __table_args__ = (
         db.UniqueConstraint('source_word_id', 'target_word_id', name='unique_translation_pair'),
-        # Add indexes for faster joins and lookups
-        Index('idx_translations_source_word_id', 'source_word_id'),
+        # target_word_id index supports reverse-direction joins; source_word_id
+        # is already covered by the unique_translation_pair constraint prefix.
         Index('idx_translations_target_word_id', 'target_word_id'),
     )
 
@@ -53,7 +60,12 @@ class DailyWord(db.Model):
     word_id = db.Column(db.Integer, db.ForeignKey("words.w_id"), nullable=False)
     en_word_id = db.Column(db.Integer, db.ForeignKey("words.w_id"), nullable=False)
     date = db.Column(db.Date, default=date.today, unique=True)
-    created_at = db.Column(db.DateTime, default=datetime.now)
+    created_at = db.Column(
+        db.DateTime,
+        nullable=False,
+        default=datetime.now,
+        server_default=func.now(),
+    )
 
     word = db.relationship("Word", foreign_keys=[word_id])
     en_word = db.relationship("Word", foreign_keys=[en_word_id])
@@ -76,13 +88,21 @@ class MissingTranslation(db.Model):
     target_language = db.Column(db.String(3), nullable=False)
     user_ip = db.Column(db.String(45))
     user_agent = db.Column(db.Text)
-    hit_count = db.Column(db.Integer, default=1)
-    created_at = db.Column(db.DateTime, default=datetime.now)
+    hit_count = db.Column(
+        db.Integer,
+        nullable=False,
+        default=1,
+        server_default=sql_text("1"),
+    )
+    created_at = db.Column(
+        db.DateTime,
+        nullable=False,
+        default=datetime.now,
+        server_default=func.now(),
+    )
 
     __table_args__ = (
         db.UniqueConstraint('text', 'source_language', 'target_language', name='unique_missing_translation'),
-        # Add composite index for faster lookups
-        Index('idx_missing_text_source_target', 'text', 'source_language', 'target_language'),
         # Add index on hit_count to quickly find most requested missing translations
         Index('idx_missing_hit_count', 'hit_count', postgresql_ops={'hit_count': 'DESC'}),
     )
@@ -98,9 +118,23 @@ class Example(db.Model):
     translation_id = db.Column(db.Integer, db.ForeignKey('translations.t_id', ondelete='CASCADE'), nullable=False)
     example_source = db.Column(db.Text, nullable=False)
     example_target = db.Column(db.Text, nullable=False)
-    created_at = db.Column(db.DateTime, default=datetime.now)
+    created_at = db.Column(
+        db.DateTime,
+        nullable=False,
+        default=datetime.now,
+        server_default=func.now(),
+    )
 
     translation = db.relationship('Translation', backref='examples')
+
+    __table_args__ = (
+        db.UniqueConstraint(
+            'translation_id',
+            'example_source',
+            'example_target',
+            name='unique_example_per_translation',
+        ),
+    )
 
     def __repr__(self):
         return f"<Example for Translation {self.translation_id}>"
@@ -112,11 +146,15 @@ class Proverb(db.Model):
     p_id = db.Column(db.Integer, primary_key=True)
     yoruba_text = db.Column(db.Text, nullable=False)
     english_text = db.Column(db.Text, nullable=False)
-    created_at = db.Column(db.DateTime, default=datetime.now)
+    created_at = db.Column(
+        db.DateTime,
+        nullable=False,
+        default=datetime.now,
+        server_default=func.now(),
+    )
 
     __table_args__ = (
         db.UniqueConstraint('yoruba_text', 'english_text', name='unique_proverb_pair'),
-        Index('idx_proverbs_yoruba_text', 'yoruba_text'),
     )
 
     def __repr__(self):

--- a/alarino_backend/src/alarino_backend/db_models.py
+++ b/alarino_backend/src/alarino_backend/db_models.py
@@ -1,15 +1,48 @@
 from datetime import date, datetime
-from sqlalchemy import Index, func
+from sqlalchemy import Index, String, Text, func
 from sqlalchemy import text as sql_text
+from sqlalchemy.types import TypeDecorator
 
 from alarino_backend.flask_extensions import db
+from alarino_backend.normalization import normalize_text, normalize_word_text
+
+
+class NFCWord(TypeDecorator):
+    """Word-level canonical text column. Mirrors normalize_word_text():
+    strip outer whitespace + punctuation, lowercase, then NFC. Applied at
+    SQLAlchemy bind time so every ORM write *and* every parameterized query
+    against this column normalizes the value, regardless of whether the
+    call site remembered to. Defense against a class of drift bugs we
+    repeatedly hit during the schema evolution work."""
+
+    impl = String
+    cache_ok = True
+
+    def process_bind_param(self, value, dialect):
+        if value is None:
+            return None
+        return normalize_word_text(value)
+
+
+class NFCText(TypeDecorator):
+    """Sentence/proverb-level canonical text column. Mirrors normalize_text():
+    strip leading and trailing whitespace then NFC. Case and inner punctuation
+    preserved. Same bind-time normalization guarantee as NFCWord."""
+
+    impl = Text
+    cache_ok = True
+
+    def process_bind_param(self, value, dialect):
+        if value is None:
+            return None
+        return normalize_text(value)
 
 class Word(db.Model):
     __tablename__ = 'words'
 
     w_id = db.Column(db.Integer, primary_key=True)
     language = db.Column(db.String(3), nullable=False)
-    word = db.Column(db.String(200), nullable=False)  ##todo: rename to text
+    word = db.Column(NFCWord(200), nullable=False)  ##todo: rename to text
     part_of_speech = db.Column(db.String(20))
     created_at = db.Column(
         db.DateTime,
@@ -87,7 +120,7 @@ class MissingTranslation(db.Model):
     __tablename__ = 'missing_translations'
 
     m_id = db.Column(db.Integer, primary_key=True)
-    text = db.Column(db.String(200), nullable=False)
+    text = db.Column(NFCWord(200), nullable=False)
     source_language = db.Column(db.String(3), nullable=False)
     target_language = db.Column(db.String(3), nullable=False)
     user_agent = db.Column(db.Text)
@@ -155,8 +188,8 @@ class Proverb(db.Model):
     __tablename__ = 'proverbs'
 
     p_id = db.Column(db.Integer, primary_key=True)
-    yoruba_text = db.Column(db.Text, nullable=False)
-    english_text = db.Column(db.Text, nullable=False)
+    yoruba_text = db.Column(NFCText, nullable=False)
+    english_text = db.Column(NFCText, nullable=False)
     created_at = db.Column(
         db.DateTime,
         nullable=False,

--- a/alarino_backend/src/alarino_backend/normalization.py
+++ b/alarino_backend/src/alarino_backend/normalization.py
@@ -1,0 +1,87 @@
+"""Canonical text normalization for alarino.
+
+Lives in its own module (no DB dependency) so it can be imported by both
+the ORM layer (db_models.py — for the NFCWord/NFCText TypeDecorators) and
+the service layer (seed_data_utils.py, translation_service.py — for read
+paths and explicit pre-write normalization).
+
+The TypeDecorators in db_models.py call these functions at SQLAlchemy
+bind time, which means every ORM write and every parameterized query
+goes through the same normalization regardless of whether the call site
+remembered to normalize first. The explicit calls in the service layer
+remain as defense in depth (redundant but harmless under the
+TypeDecorator) and as the only normalization for paths that don't touch
+the ORM (e.g., translate_llm passes user input to an LLM, not to a query).
+"""
+
+import unicodedata
+
+
+def normalize_word_text(text: str) -> str:
+    """Canonical normalization for word lookups: strip surrounding whitespace
+    and punctuation, lowercase, then NFC. Storage and read paths must both go
+    through this so canonically-equivalent inputs (e.g., precomposed vs.
+    decomposed Yoruba diacritics) collapse to the same key."""
+    cleaned = text.strip().strip(" ,.?!()").lower()
+    return unicodedata.normalize("NFC", cleaned)
+
+
+def normalize_text(text: str) -> str:
+    """Canonical normalization for sentence/proverb-level text: strip leading
+    and trailing whitespace, then NFC. Case is preserved (proverbs may carry
+    intentional capitalization) and inner punctuation is preserved."""
+    return unicodedata.normalize("NFC", text.strip())
+
+
+def audit_normalization_integrity(db) -> dict[str, list[int]]:
+    """Scan every canonical text column and return the row IDs whose stored
+    value is not the canonical form expected by its column type.
+
+    Returns a dict keyed by ``"table.column"`` mapping to a sorted list of
+    primary-key IDs that violate the invariant. An empty value list means
+    the column is clean. An empty top-level dict means everything is clean.
+
+    Intended uses:
+    - Smoke test in CI against staging after migrations.
+    - Periodic agentic drift detector that opens a GitHub issue if any
+      list is non-empty (Phase 3c).
+    - Belt-and-suspenders check in tests to confirm the NFCWord/NFCText
+      TypeDecorators are doing their job.
+
+    The check runs in Python (using the same ``normalize_word_text`` /
+    ``normalize_text`` helpers the column types use) so it is portable
+    across SQLite and Postgres without needing Postgres's
+    ``unicode_normalize()`` function. For very large tables this is
+    O(N) per check; alarino is well below the size where that matters.
+    """
+    from alarino_backend.db_models import MissingTranslation, Proverb, Word
+
+    violations: dict[str, list[int]] = {}
+
+    for row in db.session.query(Word.w_id, Word.word).all():
+        if row.word != normalize_word_text(row.word):
+            violations.setdefault("words.word", []).append(row.w_id)
+
+    for row in db.session.query(
+        MissingTranslation.m_id, MissingTranslation.text
+    ).all():
+        if row.text != normalize_word_text(row.text):
+            violations.setdefault(
+                "missing_translations.text", []
+            ).append(row.m_id)
+
+    for row in db.session.query(
+        Proverb.p_id, Proverb.yoruba_text, Proverb.english_text
+    ).all():
+        if row.yoruba_text != normalize_text(row.yoruba_text):
+            violations.setdefault(
+                "proverbs.yoruba_text", []
+            ).append(row.p_id)
+        if row.english_text != normalize_text(row.english_text):
+            violations.setdefault(
+                "proverbs.english_text", []
+            ).append(row.p_id)
+
+    for key in violations:
+        violations[key].sort()
+    return violations

--- a/alarino_backend/src/alarino_backend/normalization.py
+++ b/alarino_backend/src/alarino_backend/normalization.py
@@ -58,9 +58,9 @@ def audit_normalization_integrity(db) -> dict[str, list[int]]:
 
     violations: dict[str, list[int]] = {}
 
-    for row in db.session.query(Word.w_id, Word.word).all():
-        if row.word != normalize_word_text(row.word):
-            violations.setdefault("words.word", []).append(row.w_id)
+    for row in db.session.query(Word.w_id, Word.text).all():
+        if row.text != normalize_word_text(row.text):
+            violations.setdefault("words.text", []).append(row.w_id)
 
     for row in db.session.query(
         MissingTranslation.m_id, MissingTranslation.text

--- a/alarino_backend/src/alarino_backend/parts_of_speech.py
+++ b/alarino_backend/src/alarino_backend/parts_of_speech.py
@@ -1,0 +1,33 @@
+"""Canonical part-of-speech codes for alarino.
+
+str-backed Enum, mirroring the alarino_backend.languages.Language pattern.
+Values are the short linguistic abbreviations stored in the DB. CHECK
+constraints on words.part_of_speech and senses.part_of_speech allow NULL
+(not every word needs POS marked) or any value from this set.
+
+Adding a new POS code requires both a new enum entry here and an Alembic
+migration that drops + re-adds the CHECK constraints with the broader
+allowed set."""
+
+from enum import Enum
+
+
+class PartOfSpeech(str, Enum):
+    NOUN = "n"
+    VERB = "v"
+    ADJECTIVE = "adj"
+    ADVERB = "adv"
+    PRONOUN = "pron"
+    PREPOSITION = "prep"
+    CONJUNCTION = "conj"
+    INTERJECTION = "interj"
+    DETERMINER = "det"
+    NUMERAL = "num"
+    PARTICLE = "part"
+
+    def __str__(self):
+        return self.value
+
+
+# Sorted for stable CHECK-constraint SQL across migrations.
+ALLOWED_POS_VALUES: tuple[str, ...] = tuple(sorted(p.value for p in PartOfSpeech))

--- a/alarino_backend/src/alarino_backend/response.py
+++ b/alarino_backend/src/alarino_backend/response.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass, asdict, field
 from typing import List, Optional, Any
 
 from alarino_backend.languages import Language
@@ -11,10 +11,46 @@ class BaseResponseData:
 
 
 @dataclass
+class TranslationInSenseGroup:
+    """A single target-language translation surfaced under a sense group.
+    Carries the per-Translation metadata (note, provenance) as well as
+    sense-scoped examples (Phase 6b backfilled examples to point at sense
+    pairs; this surfaces them here)."""
+
+    word: str
+    note: Optional[str] = None
+    provenance: Optional[str] = None
+    examples: List[dict] = field(default_factory=list)
+
+
+@dataclass
+class SenseGroup:
+    """Sense-grouped translation results, added in Phase 6c. One group per
+    distinct sense of the looked-up word. ``label``, ``definition``,
+    ``register``, ``domain``, ``part_of_speech`` come from the looked-up
+    word's sense; ``translations`` lists target-language matches under
+    that sense.
+
+    Today most words have a single default sense with NULL metadata
+    fields, so a typical response carries one group with mostly-empty
+    metadata. As polysemy data is curated (e.g., "bank — financial" vs
+    "bank — riverbank") the same response shape naturally surfaces
+    multiple groups without an API rev."""
+
+    label: Optional[str] = None
+    definition: Optional[str] = None
+    register: Optional[str] = None
+    domain: Optional[str] = None
+    part_of_speech: Optional[str] = None
+    translations: List[TranslationInSenseGroup] = field(default_factory=list)
+
+
+@dataclass
 class TranslationResponseData(BaseResponseData):
     translation: List[str]
     source_word: str
     to_language: Language
+    senses: List[SenseGroup] = field(default_factory=list)
 
 
 @dataclass

--- a/alarino_backend/src/alarino_backend/translation_service.py
+++ b/alarino_backend/src/alarino_backend/translation_service.py
@@ -5,8 +5,8 @@ from datetime import date
 import threading
 from typing import Tuple, Dict, Optional
 
-from alarino_backend.data.seed_data_utils import add_word, create_translation, is_valid_english_word, is_valid_yoruba_word
-from alarino_backend.db_models import Word, DailyWord, Translation, MissingTranslation, Proverb
+from alarino_backend.data.seed_data_utils import add_word, create_translation, is_valid_english_word, is_valid_yoruba_word, normalize_word_text
+from alarino_backend.db_models import Word, DailyWord, Translation, MissingTranslation, Proverb, ProverbWord
 from alarino_backend.languages import Language
 from alarino_backend.llm_service import get_llm_service
 from alarino_backend.response import APIResponse, TranslationResponseData, WordOfTheDayResponseData, ProverbResponseData, BulkUploadResponseData
@@ -15,7 +15,7 @@ from alarino_backend.runtime import logger
 
 def translate_llm(text: str, source: Language, target: Language) -> tuple[dict, int]:
     """Translates text using the LLM service."""
-    text = text.strip().lower()
+    text = normalize_word_text(text)
     if not text:
         return APIResponse.error("Text must not be empty.", 400).as_response()
 
@@ -39,14 +39,14 @@ def translate_llm(text: str, source: Language, target: Language) -> tuple[dict, 
         return APIResponse.error("An error occurred during translation.", 500).as_response()
 
 
-def translate(db, text: str, source: Language, target: Language, addr: str, user_agent: str) -> tuple[dict, int]:
-    text = text.strip().lower()
+def translate(db, text: str, source: Language, target: Language, user_agent: str) -> tuple[dict, int]:
+    text = normalize_word_text(text)
     if not text:
         return APIResponse.error("Text must not be empty.", 400).as_response()
 
     source_word = Word.query.filter_by(language=source, word=text).first()
     if not source_word:
-        log_missing_translation(db, text, source, target, addr, user_agent)
+        log_missing_translation(db, text, source, target, user_agent)
         return APIResponse.error("Word not found.", 404).as_response()
 
     translations = (
@@ -57,7 +57,7 @@ def translate(db, text: str, source: Language, target: Language, addr: str, user
         .all()
     )
     if not translations:
-        log_missing_translation(db, text, source, target, addr, user_agent)
+        log_missing_translation(db, text, source, target, user_agent)
         return APIResponse.error("Word found but translation not available.", 404).as_response()
 
     translated_words = [t.target_word.word for t in translations]
@@ -71,9 +71,9 @@ def translate(db, text: str, source: Language, target: Language, addr: str, user
     return APIResponse.success("Translation successful.", response_data).as_response()
 
 
-def log_missing_translation(db, text, source_lang, target_lang, addr, user_agent):
-    # Atomic upsert: on first hit insert with addr/user_agent and hit_count=1; on
-    # subsequent hits increment hit_count without overwriting addr/user_agent. The
+def log_missing_translation(db, text, source_lang, target_lang, user_agent):
+    # Atomic upsert: on first hit insert with user_agent and hit_count=1; on
+    # subsequent hits increment hit_count without overwriting user_agent. The
     # previous read-modify-write pattern lost concurrent increments under load.
     dialect_name = db.session.get_bind().dialect.name
     if dialect_name == "postgresql":
@@ -90,7 +90,6 @@ def log_missing_translation(db, text, source_lang, target_lang, addr, user_agent
         text=text,
         source_language=source_lang,
         target_language=target_lang,
-        user_ip=addr,
         user_agent=user_agent,
     )
     stmt = stmt.on_conflict_do_update(
@@ -198,6 +197,28 @@ def get_word_of_the_day(db, daily_word_cache: Dict[date, Tuple[str, str]]) -> Tu
 
     except Exception as e:
         return APIResponse.error(str(e), 500).as_response()
+
+
+def get_proverbs_containing(db, language: Language, word_text: str) -> list[Proverb]:
+    """Return every Proverb whose `proverb_words` join entries reference a Word
+    matching (language, word_text). Returns an empty list if no match.
+
+    Phase 3 backfill is best-effort: proverbs that predate Phase 3 are linked
+    only if their tokenized words match an existing Word row at backfill time.
+    Misses are silently skipped, so a missing result here does not necessarily
+    mean the proverb does not contain the word — it may just predate the link.
+    """
+    word_text = normalize_word_text(word_text)
+    if not word_text:
+        return []
+    return (
+        Proverb.query
+        .join(ProverbWord, ProverbWord.proverb_id == Proverb.p_id)
+        .join(Word, Word.w_id == ProverbWord.word_id)
+        .filter(Word.language == language, Word.word == word_text)
+        .distinct()
+        .all()
+    )
 
 
 def get_random_proverb(db):

--- a/alarino_backend/src/alarino_backend/translation_service.py
+++ b/alarino_backend/src/alarino_backend/translation_service.py
@@ -72,24 +72,32 @@ def translate(db, text: str, source: Language, target: Language, addr: str, user
 
 
 def log_missing_translation(db, text, source_lang, target_lang, addr, user_agent):
-    existing = MissingTranslation.query.filter_by(
+    # Atomic upsert: on first hit insert with addr/user_agent and hit_count=1; on
+    # subsequent hits increment hit_count without overwriting addr/user_agent. The
+    # previous read-modify-write pattern lost concurrent increments under load.
+    dialect_name = db.session.get_bind().dialect.name
+    if dialect_name == "postgresql":
+        from sqlalchemy.dialects.postgresql import insert
+    elif dialect_name == "sqlite":
+        from sqlalchemy.dialects.sqlite import insert
+    else:
+        raise NotImplementedError(
+            f"log_missing_translation upsert not implemented for dialect {dialect_name!r}"
+        )
+
+    table = MissingTranslation.__table__
+    stmt = insert(table).values(
         text=text,
         source_language=source_lang,
-        target_language=target_lang
-    ).first()
-
-    if existing:
-        existing.hit_count += 1
-    else:
-        missing = MissingTranslation(
-            text=text,
-            source_language=source_lang,
-            target_language=target_lang,
-            user_ip=addr,
-            user_agent=user_agent
-        )
-        db.session.add(missing)
-
+        target_language=target_lang,
+        user_ip=addr,
+        user_agent=user_agent,
+    )
+    stmt = stmt.on_conflict_do_update(
+        index_elements=["text", "source_language", "target_language"],
+        set_={"hit_count": table.c.hit_count + 1},
+    )
+    db.session.execute(stmt)
     db.session.commit()
 
 

--- a/alarino_backend/src/alarino_backend/translation_service.py
+++ b/alarino_backend/src/alarino_backend/translation_service.py
@@ -118,43 +118,46 @@ def log_missing_translation(db, text, source_lang, target_lang, user_agent):
     db.session.commit()
 
 
-def find_single_word_with_translation(db, can_reuse=True) -> Optional[Tuple[Word, Word]]:
-    """
-    Find a random Yoruba word that has an English translation.
-    Returns a tuple of (yoruba_word, english_word) or None if no suitable word is found.
-    """
-    # Get list of previously used word IDs to avoid repetition
-    used_word_ids = db.session.query(DailyWord.word_id).all()
-    used_ids_set = set() if can_reuse else set(word_id for (word_id,) in used_word_ids)
+def _derive_yoruba_english(translation: Translation) -> Tuple[Word, Word]:
+    """Return (yoruba_word, english_word) for a translation, regardless of
+    which column each language sits in. Translation rows are directed (Phase 4
+    keeps them that way), so the Yoruba/English assignment cannot be derived
+    from source/target position — only from Word.language."""
+    sw, tw = translation.source_word, translation.target_word
+    if sw.language == Language.YORUBA.value:
+        return sw, tw
+    return tw, sw
 
-    # Filter Yoruba words that are single-word and not used before
-    selected_word = (
-        Word.query
-        .filter(Word.language == Language.YORUBA)
-        .filter(~Word.word.contains(" "))
-        .filter(~Word.w_id.in_(used_ids_set))
-        .order_by(db.func.random())
-        .first()
-    )
 
-    if not selected_word:
-        return None
+def find_random_unused_translation(db, can_reuse: bool = True) -> Optional[Translation]:
+    """Pick a random Translation that hasn't been used as a daily word, with
+    the Yoruba side restricted to single-word entries (the daily-word feature
+    spotlights individual Yoruba words, not phrases). With can_reuse=True the
+    used-set filter is skipped — same semantic as the previous version.
 
-    # Find the English translations
-    translations = (
-        Translation.query
-        .filter_by(target_word_id=selected_word.w_id)
-        .join(Word, Translation.source_word_id == Word.w_id)
-        .filter(Word.language == Language.ENGLISH)
-        .all()
-    )
+    Phase 4 keeps Translation as a directed edge, so the Yoruba side may sit
+    on either source_word or target_word. The single-word filter is applied
+    in Python rather than SQL because the "yoruba side is on one of two
+    columns" condition is awkward to express portably; alarino's translations
+    table is small enough that loading the candidate set is negligible."""
+    query = Translation.query
+    if not can_reuse:
+        used_set = {
+            t_id for (t_id,) in db.session.query(DailyWord.translation_id).all()
+        }
+        if used_set:
+            query = query.filter(~Translation.t_id.in_(used_set))
 
-    if not translations:
-        return None
-
-    # Get the first English translation
-    english_word = translations[0].source_word
-    return selected_word, english_word
+    yoruba = Language.YORUBA.value
+    for translation in query.order_by(db.func.random()).all():
+        yo_word = (
+            translation.source_word
+            if translation.source_word.language == yoruba
+            else translation.target_word
+        )
+        if " " not in yo_word.word:
+            return translation
+    return None
 
 
 def get_word_of_the_day(db, daily_word_cache: Dict[date, Tuple[str, str]]) -> Tuple[Dict, int]:
@@ -176,42 +179,32 @@ def get_word_of_the_day(db, daily_word_cache: Dict[date, Tuple[str, str]]) -> Tu
         # Check if already selected today in the DB
         existing = DailyWord.query.filter_by(date=today).first()
         if existing:
-            yoruba_word = existing.word.word
-            # Use the direct en_word relationship if available
-            if existing.en_word:
-                english_word = existing.en_word.word
-                daily_word_cache[today] = (yoruba_word, english_word)
+            yoruba_word_obj, english_word_obj = _derive_yoruba_english(existing.translation)
+            yoruba_word = yoruba_word_obj.word
+            english_word = english_word_obj.word
+            daily_word_cache[today] = (yoruba_word, english_word)
 
-                response_data = WordOfTheDayResponseData(yoruba_word=yoruba_word, english_word=english_word)
-                return APIResponse.success("Word of the day fetched from database.", response_data).as_response()
-            else:
-                # If no English word is associated, this is an error condition
-                return APIResponse.error("Daily word has no English translation", 500).as_response()
+            response_data = WordOfTheDayResponseData(yoruba_word=yoruba_word, english_word=english_word)
+            return APIResponse.success("Word of the day fetched from database.", response_data).as_response()
 
-        # Maximum attempts to find a word with translation
-        max_attempts = 5
-        for _ in range(max_attempts):
-            word_pair = find_single_word_with_translation(db)
-            if not word_pair:
-                continue
-            yoruba_word, english_word = word_pair
+        # Pick a fresh translation for today.
+        translation = find_random_unused_translation(db)
+        if translation is None:
+            return APIResponse.error(
+                "Could not find a translation suitable for the daily word.",
+                500,
+            ).as_response()
 
-            # Save to daily_words with the English word reference
-            daily = DailyWord(
-                word=yoruba_word,
-                en_word=english_word
-            )
-            db.session.add(daily)
-            db.session.commit()
-            # Cache it
-            daily_word_cache[today] = (yoruba_word.word, english_word.word)
+        yoruba_word_obj, english_word_obj = _derive_yoruba_english(translation)
+        daily = DailyWord(translation=translation)
+        db.session.add(daily)
+        db.session.commit()
+        daily_word_cache[today] = (yoruba_word_obj.word, english_word_obj.word)
 
-            response_data = WordOfTheDayResponseData(yoruba_word=yoruba_word.word, english_word=english_word.word)
-            return APIResponse.success("Word of the day fetched successfully.", response_data).as_response()
-
-        # If we've exhausted our attempts and still haven't found a word with translation
-        return APIResponse.error("Could not find a word with an English translation after multiple attempts",
-                                 500).as_response()
+        response_data = WordOfTheDayResponseData(
+            yoruba_word=yoruba_word_obj.word, english_word=english_word_obj.word
+        )
+        return APIResponse.success("Word of the day fetched successfully.", response_data).as_response()
 
     except Exception as e:
         return APIResponse.error(str(e), 500).as_response()

--- a/alarino_backend/src/alarino_backend/translation_service.py
+++ b/alarino_backend/src/alarino_backend/translation_service.py
@@ -6,10 +6,18 @@ import threading
 from typing import Tuple, Dict, Optional
 
 from alarino_backend.data.seed_data_utils import add_word, create_translation, is_valid_english_word, is_valid_yoruba_word, normalize_word_text
-from alarino_backend.db_models import Word, DailyWord, Translation, MissingTranslation, Proverb, ProverbWord
+from alarino_backend.db_models import Word, DailyWord, Example, Sense, Translation, MissingTranslation, Proverb, ProverbWord
 from alarino_backend.languages import Language
 from alarino_backend.llm_service import get_llm_service
-from alarino_backend.response import APIResponse, TranslationResponseData, WordOfTheDayResponseData, ProverbResponseData, BulkUploadResponseData
+from alarino_backend.response import (
+    APIResponse,
+    BulkUploadResponseData,
+    ProverbResponseData,
+    SenseGroup,
+    TranslationInSenseGroup,
+    TranslationResponseData,
+    WordOfTheDayResponseData,
+)
 from alarino_backend.runtime import logger
 
 
@@ -65,15 +73,45 @@ def translate(db, text: str, source: Language, target: Language, user_agent: str
     )
     seen_word_ids: set[int] = set()
     translated_words: list[str] = []
+    # Group results by the *looked-up* word's sense (Phase 6c). For each
+    # matching translation, the looked-up side may be either source or target;
+    # the "my sense" is whichever sense FK sits on the same side. Default
+    # bucket (sense_id None) catches translations whose sense FKs are NULL —
+    # shouldn't happen post-Phase-6b for new data but kept as a safety net.
+    sense_buckets: dict[Optional[int], SenseGroup] = {}
     for translation in translations:
-        other = (
-            translation.target_word
-            if translation.source_word_id == source_word.w_id
-            else translation.source_word
+        if translation.source_word_id == source_word.w_id:
+            other = translation.target_word
+            my_sense = translation.source_sense
+            other_sense = translation.target_sense
+        else:
+            other = translation.source_word
+            my_sense = translation.target_sense
+            other_sense = translation.source_sense
+
+        if other.language != target.value or other.w_id in seen_word_ids:
+            continue
+        seen_word_ids.add(other.w_id)
+        translated_words.append(other.word)
+
+        sense_key = my_sense.sense_id if my_sense is not None else None
+        if sense_key not in sense_buckets:
+            sense_buckets[sense_key] = SenseGroup(
+                label=my_sense.sense_label if my_sense else None,
+                definition=my_sense.definition if my_sense else None,
+                register=my_sense.register if my_sense else None,
+                domain=my_sense.domain if my_sense else None,
+                part_of_speech=(my_sense.part_of_speech if my_sense else None),
+            )
+        examples = _examples_for_sense_pair(my_sense, other_sense)
+        sense_buckets[sense_key].translations.append(
+            TranslationInSenseGroup(
+                word=other.word,
+                note=translation.note,
+                provenance=translation.provenance,
+                examples=examples,
+            )
         )
-        if other.language == target.value and other.w_id not in seen_word_ids:
-            seen_word_ids.add(other.w_id)
-            translated_words.append(other.word)
 
     if not translated_words:
         log_missing_translation(db, text, source, target, user_agent)
@@ -81,12 +119,45 @@ def translate(db, text: str, source: Language, target: Language, user_agent: str
 
     logger.info(f"[Translated '{text}' from {source} to {target}]")
 
+    # Sense groups are ordered by first-seen sense_id for deterministic output;
+    # the default-sense bucket (key None) sorts to the end if present.
+    ordered_groups = sorted(
+        sense_buckets.items(),
+        key=lambda item: (item[0] is None, item[0] or 0),
+    )
     response_data = TranslationResponseData(
         translation=translated_words,
         source_word=source_word.word,
-        to_language=target
+        to_language=target,
+        senses=[group for _, group in ordered_groups],
     )
     return APIResponse.success("Translation successful.", response_data).as_response()
+
+
+def _examples_for_sense_pair(
+    source_sense: Optional[Sense], target_sense: Optional[Sense]
+) -> list[dict]:
+    """Return Example rows attached to the given (source_sense, target_sense)
+    pair, formatted as {source, target} dicts. If either sense is None, returns
+    [] — Phase 6b backfilled examples to point at sense pairs but a future
+    raw-SQL inserted Example without sense FKs would not match. Read paths
+    surface only sense-attached examples; legacy examples linked only by
+    translation_id surface through Phase 6c-incompatible read paths (none
+    exposed today) until 6d drops translation_id."""
+    if source_sense is None or target_sense is None:
+        return []
+    rows = (
+        Example.query
+        .filter_by(
+            source_sense_id=source_sense.sense_id,
+            target_sense_id=target_sense.sense_id,
+        )
+        .all()
+    )
+    return [
+        {"source": row.example_source, "target": row.example_target}
+        for row in rows
+    ]
 
 
 def log_missing_translation(db, text, source_lang, target_lang, user_agent):

--- a/alarino_backend/src/alarino_backend/translation_service.py
+++ b/alarino_backend/src/alarino_backend/translation_service.py
@@ -52,7 +52,7 @@ def translate(db, text: str, source: Language, target: Language, user_agent: str
     if not text:
         return APIResponse.error("Text must not be empty.", 400).as_response()
 
-    source_word = Word.query.filter_by(language=source, word=text).first()
+    source_word = Word.query.filter_by(language=source, text=text).first()
     if not source_word:
         log_missing_translation(db, text, source, target, user_agent)
         return APIResponse.error("Word not found.", 404).as_response()
@@ -92,7 +92,7 @@ def translate(db, text: str, source: Language, target: Language, user_agent: str
         if other.language != target.value or other.w_id in seen_word_ids:
             continue
         seen_word_ids.add(other.w_id)
-        translated_words.append(other.word)
+        translated_words.append(other.text)
 
         sense_key = my_sense.sense_id if my_sense is not None else None
         if sense_key not in sense_buckets:
@@ -106,7 +106,7 @@ def translate(db, text: str, source: Language, target: Language, user_agent: str
         examples = _examples_for_sense_pair(my_sense, other_sense)
         sense_buckets[sense_key].translations.append(
             TranslationInSenseGroup(
-                word=other.word,
+                word=other.text,
                 note=translation.note,
                 provenance=translation.provenance,
                 examples=examples,
@@ -127,7 +127,7 @@ def translate(db, text: str, source: Language, target: Language, user_agent: str
     )
     response_data = TranslationResponseData(
         translation=translated_words,
-        source_word=source_word.word,
+        source_word=source_word.text,
         to_language=target,
         senses=[group for _, group in ordered_groups],
     )
@@ -226,7 +226,7 @@ def find_random_unused_translation(db, can_reuse: bool = True) -> Optional[Trans
             if translation.source_word.language == yoruba
             else translation.target_word
         )
-        if " " not in yo_word.word:
+        if " " not in yo_word.text:
             return translation
     return None
 
@@ -251,8 +251,8 @@ def get_word_of_the_day(db, daily_word_cache: Dict[date, Tuple[str, str]]) -> Tu
         existing = DailyWord.query.filter_by(date=today).first()
         if existing:
             yoruba_word_obj, english_word_obj = _derive_yoruba_english(existing.translation)
-            yoruba_word = yoruba_word_obj.word
-            english_word = english_word_obj.word
+            yoruba_word = yoruba_word_obj.text
+            english_word = english_word_obj.text
             daily_word_cache[today] = (yoruba_word, english_word)
 
             response_data = WordOfTheDayResponseData(yoruba_word=yoruba_word, english_word=english_word)
@@ -270,10 +270,10 @@ def get_word_of_the_day(db, daily_word_cache: Dict[date, Tuple[str, str]]) -> Tu
         daily = DailyWord(translation=translation)
         db.session.add(daily)
         db.session.commit()
-        daily_word_cache[today] = (yoruba_word_obj.word, english_word_obj.word)
+        daily_word_cache[today] = (yoruba_word_obj.text, english_word_obj.text)
 
         response_data = WordOfTheDayResponseData(
-            yoruba_word=yoruba_word_obj.word, english_word=english_word_obj.word
+            yoruba_word=yoruba_word_obj.text, english_word=english_word_obj.text
         )
         return APIResponse.success("Word of the day fetched successfully.", response_data).as_response()
 
@@ -297,7 +297,7 @@ def get_proverbs_containing(db, language: Language, word_text: str) -> list[Prov
         Proverb.query
         .join(ProverbWord, ProverbWord.proverb_id == Proverb.p_id)
         .join(Word, Word.w_id == ProverbWord.word_id)
-        .filter(Word.language == language, Word.word == word_text)
+        .filter(Word.language == language, Word.text == word_text)
         .distinct()
         .all()
     )

--- a/alarino_backend/src/alarino_backend/translation_service.py
+++ b/alarino_backend/src/alarino_backend/translation_service.py
@@ -49,18 +49,36 @@ def translate(db, text: str, source: Language, target: Language, user_agent: str
         log_missing_translation(db, text, source, target, user_agent)
         return APIResponse.error("Word not found.", 404).as_response()
 
+    # Bidirectional lookup. Translation is stored as a directed edge — the
+    # curator added it as source→target — but a user querying in either
+    # direction should find a match if either direction was curated. Match the
+    # source_word on EITHER column and return the opposite-side word, filtered
+    # by the requested target language and deduped by w_id so a pair that
+    # happens to be curated in both directions doesn't return duplicates.
     translations = (
         Translation.query
-        .filter_by(source_word_id=source_word.w_id)
-        .join(Word, Translation.target_word_id == Word.w_id)
-        .filter(Word.language == target)
+        .filter(
+            (Translation.source_word_id == source_word.w_id)
+            | (Translation.target_word_id == source_word.w_id)
+        )
         .all()
     )
-    if not translations:
+    seen_word_ids: set[int] = set()
+    translated_words: list[str] = []
+    for translation in translations:
+        other = (
+            translation.target_word
+            if translation.source_word_id == source_word.w_id
+            else translation.source_word
+        )
+        if other.language == target.value and other.w_id not in seen_word_ids:
+            seen_word_ids.add(other.w_id)
+            translated_words.append(other.word)
+
+    if not translated_words:
         log_missing_translation(db, text, source, target, user_agent)
         return APIResponse.error("Word found but translation not available.", 404).as_response()
 
-    translated_words = [t.target_word.word for t in translations]
     logger.info(f"[Translated '{text}' from {source} to {target}]")
 
     response_data = TranslationResponseData(

--- a/alarino_backend/tests/test_app.py
+++ b/alarino_backend/tests/test_app.py
@@ -93,13 +93,12 @@ def test_translate_returns_service_response(client, monkeypatch):
         },
     }
 
-    def fake_translate(db_arg, text, source_language, target_language, addr, user_agent):
+    def fake_translate(db_arg, text, source_language, target_language, user_agent):
         captured.update(
             db_arg=db_arg,
             text=text,
             source_language=source_language,
             target_language=target_language,
-            addr=addr,
             user_agent=user_agent,
         )
         return payload, 200
@@ -114,7 +113,6 @@ def test_translate_returns_service_response(client, monkeypatch):
             "target_lang": Language.YORUBA.value,
         },
         headers={"User-Agent": "pytest-agent"},
-        environ_overrides={"REMOTE_ADDR": "203.0.113.10"},
     )
 
     assert response.status_code == 200
@@ -124,7 +122,6 @@ def test_translate_returns_service_response(client, monkeypatch):
         "text": "hello",
         "source_language": Language.ENGLISH,
         "target_language": Language.YORUBA,
-        "addr": "203.0.113.10",
         "user_agent": "pytest-agent",
     }
 

--- a/alarino_backend/tests/test_bulk_upload.py
+++ b/alarino_backend/tests/test_bulk_upload.py
@@ -1,0 +1,172 @@
+"""Integration tests for translation_service.bulk_upload_words.
+
+Previously the bulk-upload path was only exercised end-to-end via Docker
+against real Postgres. These tests cover the unit/integration boundary so
+regressions in input parsing, validation, and persistence are caught
+under pytest."""
+
+import pytest
+
+import alarino_backend.app as app_module
+import alarino_backend.translation_service as translation_service
+from alarino_backend import db
+from alarino_backend.db_models import Sense, Translation, Word
+
+
+@pytest.fixture
+def db_app():
+    app = app_module.create_app()
+    app.config["TESTING"] = True
+    with app.app_context():
+        db.create_all()
+        try:
+            yield app
+        finally:
+            db.session.remove()
+            db.drop_all()
+
+
+# ---- Dry-run path: validation only, nothing persisted ----
+
+
+def test_dry_run_reports_successful_pairs_without_persisting(db_app):
+    response, status = translation_service.bulk_upload_words(
+        db, "hello,bawo\nhouse,ile", dry_run=True
+    )
+    assert status == 200
+    assert response["message"] == "Bulk upload validation completed"
+    assert response["data"]["dry_run"] is True
+    assert response["data"]["successful_pairs"] == [
+        {"english": "hello", "yoruba": "bawo"},
+        {"english": "house", "yoruba": "ile"},
+    ]
+    assert response["data"]["failed_pairs"] == []
+    # Nothing committed.
+    assert Word.query.count() == 0
+    assert Translation.query.count() == 0
+
+
+def test_dry_run_reports_invalid_pairs_without_persisting(db_app):
+    response, status = translation_service.bulk_upload_words(
+        db,
+        "hello,bawo\nbad@@@english,bawo\nhouse,bad@@@yoruba",
+        dry_run=True,
+    )
+    assert status == 200
+    assert response["data"]["successful_pairs"] == [
+        {"english": "hello", "yoruba": "bawo"},
+    ]
+    failed = response["data"]["failed_pairs"]
+    assert len(failed) == 2
+    assert any("Invalid English word" in f["reason"] for f in failed)
+    assert any("Invalid Yoruba word" in f["reason"] for f in failed)
+    assert Word.query.count() == 0
+
+
+# ---- Live run path: validation + persistence ----
+
+
+def test_live_run_persists_words_and_translations(db_app):
+    response, status = translation_service.bulk_upload_words(
+        db, "hello,bawo\nhouse,ile", dry_run=False
+    )
+    assert status == 200
+    assert response["message"] == "Bulk upload process completed."
+    assert response["data"]["dry_run"] is False
+    assert len(response["data"]["successful_pairs"]) == 2
+
+    assert Word.query.filter_by(language="en", text="hello").one()
+    assert Word.query.filter_by(language="en", text="house").one()
+    assert Word.query.filter_by(language="yo", text="bawo").one()
+    assert Word.query.filter_by(language="yo", text="ile").one()
+
+    translations = Translation.query.all()
+    assert len(translations) == 2
+    # Each Translation has its sense FKs populated by the create_translation
+    # path (Phase 6b cutover).
+    for t in translations:
+        assert t.source_sense_id is not None
+        assert t.target_sense_id is not None
+
+
+def test_live_run_creates_one_default_sense_per_word(db_app):
+    translation_service.bulk_upload_words(
+        db, "hello,bawo", dry_run=False
+    )
+    assert Sense.query.count() == 2  # one per word
+    for word in Word.query.all():
+        assert (
+            Sense.query.filter_by(word_id=word.w_id).count() == 1
+        ), "create_translation should attach exactly one default sense per word"
+
+
+def test_live_run_skips_invalid_pairs_but_commits_valid_ones(db_app):
+    response, status = translation_service.bulk_upload_words(
+        db,
+        "hello,bawo\nbad@@@english,bawo\nhouse,ile",
+        dry_run=False,
+    )
+    assert status == 200
+    assert len(response["data"]["successful_pairs"]) == 2
+    assert len(response["data"]["failed_pairs"]) == 1
+    # Valid ones persisted.
+    assert Word.query.count() == 4  # hello, house, bawo, ile
+    assert Translation.query.count() == 2
+
+
+def test_live_run_is_idempotent_on_repeated_input(db_app):
+    translation_service.bulk_upload_words(
+        db, "hello,bawo", dry_run=False
+    )
+    # Re-run: words and the translation already exist; no duplicates.
+    response, status = translation_service.bulk_upload_words(
+        db, "hello,bawo", dry_run=False
+    )
+    assert status == 200
+    assert Word.query.count() == 2
+    assert Translation.query.count() == 1
+
+
+# ---- Input shape edge cases ----
+
+
+def test_skips_empty_rows(db_app):
+    response, status = translation_service.bulk_upload_words(
+        db, "\nhello,bawo\n\nhouse,ile\n", dry_run=False
+    )
+    assert status == 200
+    assert len(response["data"]["successful_pairs"]) == 2
+    assert response["data"]["failed_pairs"] == []
+
+
+def test_rejects_rows_with_wrong_column_count(db_app):
+    response, status = translation_service.bulk_upload_words(
+        db, "hello,bawo\nonly_one_column\nhello,bawo,extra", dry_run=False
+    )
+    assert status == 200
+    assert len(response["data"]["successful_pairs"]) == 1
+    failed = response["data"]["failed_pairs"]
+    assert len(failed) == 2
+    assert all(
+        "exactly two values" in f["reason"] for f in failed
+    )
+
+
+def test_strips_and_lowercases_input(db_app):
+    response, status = translation_service.bulk_upload_words(
+        db, "  HELLO  ,  BAWO  ", dry_run=False
+    )
+    assert status == 200
+    # Stored canonical form is lowercased + stripped.
+    assert Word.query.filter_by(language="en", text="hello").one()
+    assert Word.query.filter_by(language="yo", text="bawo").one()
+
+
+def test_empty_input_returns_empty_response(db_app):
+    response, status = translation_service.bulk_upload_words(
+        db, "", dry_run=False
+    )
+    assert status == 200
+    assert response["data"]["successful_pairs"] == []
+    assert response["data"]["failed_pairs"] == []
+    assert Word.query.count() == 0

--- a/alarino_backend/tests/test_daily_word.py
+++ b/alarino_backend/tests/test_daily_word.py
@@ -49,10 +49,15 @@ def test_daily_word_no_longer_has_word_id_or_en_word_id_columns():
     assert "translation_id" in columns
 
 
-def test_daily_word_translation_id_is_unique():
+def test_daily_word_translation_id_is_not_unique():
+    # Originally Phase 5 made translation_id UNIQUE, but that broke
+    # find_random_unused_translation's default can_reuse=True path (a
+    # past daily word being re-picked would crash on the constraint).
+    # Phase 7 bug-fix relaxed it. Date uniqueness still ensures one
+    # daily word per date.
     column = DailyWord.__table__.c.translation_id
     assert column.nullable is False
-    assert column.unique is True
+    assert column.unique is not True
 
 
 def test_get_word_of_the_day_picks_unused_translation_when_db_empty(db_app):
@@ -119,14 +124,40 @@ def test_find_random_unused_translation_skips_multiword_yoruba_phrases(db_app):
     assert selected is None
 
 
-def test_translation_id_unique_constraint_rejects_duplicate_daily_words(db_app):
-    from sqlalchemy.exc import IntegrityError
+def test_same_translation_can_be_daily_word_on_different_dates(db_app):
+    # P1a regression test: previously a UNIQUE on translation_id rejected
+    # the second insert and made get_word_of_the_day 500 on its second-ever
+    # call against a fresh DB. After the Phase 7 bug-fix, the same
+    # translation can be the daily word on different dates.
+    t = _seed_translation("hello", "bawo")
+    db.session.add(DailyWord(translation_id=t.t_id, date=date(2024, 1, 1)))
+    db.session.add(DailyWord(translation_id=t.t_id, date=date(2024, 1, 2)))
+    db.session.commit()
 
+    assert DailyWord.query.count() == 2
+
+
+def test_get_word_of_the_day_succeeds_when_only_translation_was_already_used(db_app):
+    # Exact P1a repro from the review: seed one old DailyWord, then call
+    # get_word_of_the_day. The picker defaults to can_reuse=True so it can
+    # legitimately return the same translation. The endpoint must not 500.
     t = _seed_translation("hello", "bawo")
     db.session.add(DailyWord(translation_id=t.t_id, date=date(2024, 1, 1)))
     db.session.commit()
+    cache = {}
 
+    response, status = translation_service.get_word_of_the_day(db, cache)
+    assert status == 200
+    assert response["data"]["yoruba_word"] == "bawo"
+    # Two rows: the seeded historical one, plus today's.
+    assert DailyWord.query.count() == 2
+
+
+def test_translation_id_uniqueness_is_not_enforced_at_db_level(db_app):
+    # Belt-and-suspenders against re-introducing the unique constraint:
+    # inserting two daily_words pointing at the same translation_id must
+    # not raise even at the DB level.
+    t = _seed_translation("hello", "bawo")
+    db.session.add(DailyWord(translation_id=t.t_id, date=date(2024, 1, 1)))
     db.session.add(DailyWord(translation_id=t.t_id, date=date(2024, 1, 2)))
-    with pytest.raises(IntegrityError):
-        db.session.commit()
-    db.session.rollback()
+    db.session.commit()  # must not raise IntegrityError

--- a/alarino_backend/tests/test_daily_word.py
+++ b/alarino_backend/tests/test_daily_word.py
@@ -30,8 +30,8 @@ def _seed_translation(en: str, yo: str, *, en_to_yo: bool = True) -> Translation
     # would fail the constraint).
     from alarino_backend.data.seed_data_utils import create_translation
 
-    en_word = Word(language="en", word=en)
-    yo_word = Word(language="yo", word=yo)
+    en_word = Word(language="en", text=en)
+    yo_word = Word(language="yo", text=yo)
     db.session.add_all([en_word, yo_word])
     db.session.flush()
     src, tgt = (en_word, yo_word) if en_to_yo else (yo_word, en_word)

--- a/alarino_backend/tests/test_daily_word.py
+++ b/alarino_backend/tests/test_daily_word.py
@@ -25,21 +25,21 @@ def db_app():
 
 
 def _seed_translation(en: str, yo: str, *, en_to_yo: bool = True) -> Translation:
+    # Route through create_translation so sense FKs are populated (Phase 6d
+    # made them NOT NULL; constructing Translation directly without sense FKs
+    # would fail the constraint).
+    from alarino_backend.data.seed_data_utils import create_translation
+
     en_word = Word(language="en", word=en)
     yo_word = Word(language="yo", word=yo)
     db.session.add_all([en_word, yo_word])
     db.session.flush()
-    if en_to_yo:
-        t = Translation(
-            source_word_id=en_word.w_id, target_word_id=yo_word.w_id
-        )
-    else:
-        t = Translation(
-            source_word_id=yo_word.w_id, target_word_id=en_word.w_id
-        )
-    db.session.add(t)
+    src, tgt = (en_word, yo_word) if en_to_yo else (yo_word, en_word)
+    create_translation(src, tgt)
     db.session.commit()
-    return t
+    return Translation.query.filter_by(
+        source_word_id=src.w_id, target_word_id=tgt.w_id
+    ).one()
 
 
 def test_daily_word_no_longer_has_word_id_or_en_word_id_columns():

--- a/alarino_backend/tests/test_daily_word.py
+++ b/alarino_backend/tests/test_daily_word.py
@@ -1,0 +1,132 @@
+"""Tests for the Phase 5 DailyWord normalization: storage now uses
+translation_id and read paths derive Yoruba/English from Word.language."""
+
+from datetime import date
+
+import pytest
+
+import alarino_backend.app as app_module
+import alarino_backend.translation_service as translation_service
+from alarino_backend import db
+from alarino_backend.db_models import DailyWord, Translation, Word
+
+
+@pytest.fixture
+def db_app():
+    app = app_module.create_app()
+    app.config["TESTING"] = True
+    with app.app_context():
+        db.create_all()
+        try:
+            yield app
+        finally:
+            db.session.remove()
+            db.drop_all()
+
+
+def _seed_translation(en: str, yo: str, *, en_to_yo: bool = True) -> Translation:
+    en_word = Word(language="en", word=en)
+    yo_word = Word(language="yo", word=yo)
+    db.session.add_all([en_word, yo_word])
+    db.session.flush()
+    if en_to_yo:
+        t = Translation(
+            source_word_id=en_word.w_id, target_word_id=yo_word.w_id
+        )
+    else:
+        t = Translation(
+            source_word_id=yo_word.w_id, target_word_id=en_word.w_id
+        )
+    db.session.add(t)
+    db.session.commit()
+    return t
+
+
+def test_daily_word_no_longer_has_word_id_or_en_word_id_columns():
+    columns = {c.name for c in DailyWord.__table__.columns}
+    assert "word_id" not in columns
+    assert "en_word_id" not in columns
+    assert "translation_id" in columns
+
+
+def test_daily_word_translation_id_is_unique():
+    column = DailyWord.__table__.c.translation_id
+    assert column.nullable is False
+    assert column.unique is True
+
+
+def test_get_word_of_the_day_picks_unused_translation_when_db_empty(db_app):
+    t = _seed_translation("hello", "bawo")
+    cache = {}
+
+    response, status = translation_service.get_word_of_the_day(db, cache)
+
+    assert status == 200
+    assert response["data"]["yoruba_word"] == "bawo"
+    assert response["data"]["english_word"] == "hello"
+    # Persisted under the expected translation_id.
+    daily = DailyWord.query.one()
+    assert daily.translation_id == t.t_id
+    assert daily.date == date.today()
+
+
+def test_get_word_of_the_day_works_when_translation_was_curated_yo_to_en(db_app):
+    # Phase 4 keeps directed storage. The daily-word read path must derive
+    # the Yoruba/English sides from Word.language, NOT from positional
+    # source/target. Seed a translation curated in the YO→EN direction
+    # (yoruba is source_word_id, english is target_word_id) and verify the
+    # response still shows the Yoruba side as yoruba_word.
+    _seed_translation("hello", "bawo", en_to_yo=False)
+    cache = {}
+
+    response, status = translation_service.get_word_of_the_day(db, cache)
+
+    assert status == 200
+    assert response["data"]["yoruba_word"] == "bawo"
+    assert response["data"]["english_word"] == "hello"
+
+
+def test_get_word_of_the_day_returns_existing_daily_word_when_present(db_app):
+    t = _seed_translation("hello", "bawo")
+    db.session.add(DailyWord(translation_id=t.t_id, date=date.today()))
+    db.session.commit()
+    cache = {}
+
+    response, status = translation_service.get_word_of_the_day(db, cache)
+
+    assert status == 200
+    assert response["data"]["yoruba_word"] == "bawo"
+    assert response["data"]["english_word"] == "hello"
+    # No additional row created.
+    assert DailyWord.query.count() == 1
+
+
+def test_find_random_unused_translation_excludes_used_translations(db_app):
+    t1 = _seed_translation("hello", "bawo")
+    t2 = _seed_translation("house", "ile")
+    db.session.add(DailyWord(translation_id=t1.t_id, date=date(2024, 1, 1)))
+    db.session.commit()
+
+    selected = translation_service.find_random_unused_translation(db, can_reuse=False)
+    assert selected is not None
+    assert selected.t_id == t2.t_id
+
+
+def test_find_random_unused_translation_skips_multiword_yoruba_phrases(db_app):
+    # Daily-word feature should only pick single-word Yoruba entries.
+    _seed_translation("phrase", "ile mi")
+    selected = translation_service.find_random_unused_translation(db)
+    assert selected is None
+
+
+def test_translation_id_unique_constraint_rejects_duplicate_daily_words(db_app):
+    from sqlalchemy.exc import IntegrityError
+
+    t = _seed_translation("hello", "bawo")
+    db.session.add(DailyWord(translation_id=t.t_id, date=date(2024, 1, 1)))
+    db.session.commit()
+
+    db.session.add(DailyWord(translation_id=t.t_id, date=date(2024, 1, 2)))
+    with pytest.raises(IntegrityError):
+        db.session.commit()
+    db.session.rollback()

--- a/alarino_backend/tests/test_db_models.py
+++ b/alarino_backend/tests/test_db_models.py
@@ -74,11 +74,11 @@ def test_redundant_indexes_are_not_declared_on_models():
 
 
 def test_inserting_word_without_created_at_uses_server_default(db_app):
-    word = Word(language="yo", word="ile")
+    word = Word(language="yo", text="ile")
     db.session.add(word)
     db.session.commit()
 
-    refreshed = Word.query.filter_by(language="yo", word="ile").one()
+    refreshed = Word.query.filter_by(language="yo", text="ile").one()
     assert refreshed.created_at is not None
 
 
@@ -88,7 +88,7 @@ def test_missing_translation_no_longer_has_user_ip_column():
 
 
 def test_word_language_check_constraint_rejects_invalid_code(db_app):
-    db.session.add(Word(language="zz", word="bogus"))
+    db.session.add(Word(language="zz", text="bogus"))
     with pytest.raises(IntegrityError):
         db.session.commit()
     db.session.rollback()
@@ -118,7 +118,7 @@ def test_proverb_words_table_exists_with_check_constraint():
 
 def test_proverb_word_language_check_rejects_invalid_code(db_app):
     proverb = Proverb(yoruba_text="t1", english_text="t1-en")
-    word = Word(language="yo", word="ile")
+    word = Word(language="yo", text="ile")
     db.session.add_all([proverb, word])
     db.session.flush()
 
@@ -139,8 +139,8 @@ def test_duplicate_example_is_rejected(db_app):
     # Phase 6d: examples uniqueness is on the sense-pair plus text.
     from alarino_backend.db_models import Sense
 
-    yoruba = Word(language="yo", word="ile")
-    english = Word(language="en", word="house")
+    yoruba = Word(language="yo", text="ile")
+    english = Word(language="en", text="house")
     db.session.add_all([yoruba, english])
     db.session.flush()
     yo_sense = Sense(word_id=yoruba.w_id)

--- a/alarino_backend/tests/test_db_models.py
+++ b/alarino_backend/tests/test_db_models.py
@@ -1,0 +1,109 @@
+"""Tests for db_models.py schema constraints introduced by the schema
+evolution plan. These guard against regressions in column metadata; the
+migrations themselves are exercised separately via `flask db upgrade`."""
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+import alarino_backend.app as app_module
+from alarino_backend import db
+from alarino_backend.db_models import (
+    Example,
+    MissingTranslation,
+    Translation,
+    Word,
+)
+
+
+TIMESTAMPED_MODELS = (Word, Translation, MissingTranslation, Example)
+
+
+@pytest.fixture
+def db_app():
+    app = app_module.create_app()
+    app.config["TESTING"] = True
+    with app.app_context():
+        db.create_all()
+        try:
+            yield app
+        finally:
+            db.session.remove()
+            db.drop_all()
+
+
+@pytest.mark.parametrize("model", TIMESTAMPED_MODELS, ids=lambda m: m.__name__)
+def test_created_at_is_not_null_with_server_default(model):
+    column = model.__table__.c.created_at
+    assert column.nullable is False, (
+        f"{model.__name__}.created_at must be NOT NULL"
+    )
+    assert column.server_default is not None, (
+        f"{model.__name__}.created_at must have a server_default"
+    )
+
+
+def test_missing_translation_hit_count_is_not_null_with_default():
+    column = MissingTranslation.__table__.c.hit_count
+    assert column.nullable is False
+    assert column.server_default is not None
+
+
+def test_example_has_unique_constraint():
+    constraint_names = {c.name for c in Example.__table__.constraints}
+    assert "unique_example_per_translation" in constraint_names
+
+
+def test_redundant_indexes_are_not_declared_on_models():
+    # These indexes were redundant with their unique constraints (or unused
+    # in the planner); Phase 1 dropped them and the model definitions must
+    # not redeclare them.
+    declared_indexes = (
+        {idx.name for idx in Word.__table__.indexes}
+        | {idx.name for idx in Translation.__table__.indexes}
+        | {idx.name for idx in MissingTranslation.__table__.indexes}
+    )
+    assert "idx_words_language_word" not in declared_indexes
+    assert "idx_words_language" not in declared_indexes
+    assert "idx_missing_text_source_target" not in declared_indexes
+    assert "idx_translations_source_word_id" not in declared_indexes
+
+
+def test_inserting_word_without_created_at_uses_server_default(db_app):
+    word = Word(language="yo", word="ile")
+    db.session.add(word)
+    db.session.commit()
+
+    refreshed = Word.query.filter_by(language="yo", word="ile").one()
+    assert refreshed.created_at is not None
+
+
+def test_duplicate_example_is_rejected(db_app):
+    yoruba = Word(language="yo", word="ile")
+    english = Word(language="en", word="house")
+    db.session.add_all([yoruba, english])
+    db.session.flush()
+    translation = Translation(
+        source_word_id=yoruba.w_id, target_word_id=english.w_id
+    )
+    db.session.add(translation)
+    db.session.flush()
+
+    db.session.add(
+        Example(
+            translation_id=translation.t_id,
+            example_source="ile mi",
+            example_target="my house",
+        )
+    )
+    db.session.commit()
+
+    db.session.add(
+        Example(
+            translation_id=translation.t_id,
+            example_source="ile mi",
+            example_target="my house",
+        )
+    )
+    with pytest.raises(IntegrityError):
+        db.session.commit()
+    db.session.rollback()

--- a/alarino_backend/tests/test_db_models.py
+++ b/alarino_backend/tests/test_db_models.py
@@ -10,6 +10,8 @@ from alarino_backend import db
 from alarino_backend.db_models import (
     Example,
     MissingTranslation,
+    Proverb,
+    ProverbWord,
     Translation,
     Word,
 )
@@ -75,6 +77,59 @@ def test_inserting_word_without_created_at_uses_server_default(db_app):
 
     refreshed = Word.query.filter_by(language="yo", word="ile").one()
     assert refreshed.created_at is not None
+
+
+def test_missing_translation_no_longer_has_user_ip_column():
+    columns = {c.name for c in MissingTranslation.__table__.columns}
+    assert "user_ip" not in columns
+
+
+def test_word_language_check_constraint_rejects_invalid_code(db_app):
+    db.session.add(Word(language="zz", word="bogus"))
+    with pytest.raises(IntegrityError):
+        db.session.commit()
+    db.session.rollback()
+
+
+def test_missing_translation_language_check_constraint_rejects_invalid_code(db_app):
+    db.session.add(
+        MissingTranslation(
+            text="ile",
+            source_language="zz",
+            target_language="en",
+            user_agent="pytest-agent",
+        )
+    )
+    with pytest.raises(IntegrityError):
+        db.session.commit()
+    db.session.rollback()
+
+
+def test_proverb_words_table_exists_with_check_constraint():
+    table = ProverbWord.__table__
+    constraint_names = {c.name for c in table.constraints}
+    assert "ck_proverb_words_language_valid" in constraint_names
+    pk_columns = {c.name for c in table.primary_key.columns}
+    assert pk_columns == {"proverb_id", "word_id", "language", "position"}
+
+
+def test_proverb_word_language_check_rejects_invalid_code(db_app):
+    proverb = Proverb(yoruba_text="t1", english_text="t1-en")
+    word = Word(language="yo", word="ile")
+    db.session.add_all([proverb, word])
+    db.session.flush()
+
+    db.session.add(
+        ProverbWord(
+            proverb_id=proverb.p_id,
+            word_id=word.w_id,
+            language="zz",
+            position=0,
+        )
+    )
+    with pytest.raises(IntegrityError):
+        db.session.commit()
+    db.session.rollback()
 
 
 def test_duplicate_example_is_rejected(db_app):

--- a/alarino_backend/tests/test_db_models.py
+++ b/alarino_backend/tests/test_db_models.py
@@ -61,16 +61,17 @@ def test_example_has_unique_constraint():
 def test_redundant_indexes_are_not_declared_on_models():
     # These indexes were redundant with their unique constraints (or unused
     # in the planner); Phase 1 dropped them and the model definitions must
-    # not redeclare them.
+    # not redeclare them. Note: idx_translations_source_word_id was dropped
+    # in Phase 1 (covered by unique_translation_pair prefix), then re-added
+    # in the Phase 7 bug-fix when uniqueness moved to the sense pair — it
+    # is no longer redundant.
     declared_indexes = (
         {idx.name for idx in Word.__table__.indexes}
-        | {idx.name for idx in Translation.__table__.indexes}
         | {idx.name for idx in MissingTranslation.__table__.indexes}
     )
     assert "idx_words_language_word" not in declared_indexes
     assert "idx_words_language" not in declared_indexes
     assert "idx_missing_text_source_target" not in declared_indexes
-    assert "idx_translations_source_word_id" not in declared_indexes
 
 
 def test_inserting_word_without_created_at_uses_server_default(db_app):

--- a/alarino_backend/tests/test_db_models.py
+++ b/alarino_backend/tests/test_db_models.py
@@ -51,8 +51,11 @@ def test_missing_translation_hit_count_is_not_null_with_default():
 
 
 def test_example_has_unique_constraint():
+    # Phase 6d renamed unique_example_per_translation to
+    # unique_example_per_sense_pair (translation_id was dropped; uniqueness
+    # is now on the sense pair plus the example text).
     constraint_names = {c.name for c in Example.__table__.constraints}
-    assert "unique_example_per_translation" in constraint_names
+    assert "unique_example_per_sense_pair" in constraint_names
 
 
 def test_redundant_indexes_are_not_declared_on_models():
@@ -133,30 +136,34 @@ def test_proverb_word_language_check_rejects_invalid_code(db_app):
 
 
 def test_duplicate_example_is_rejected(db_app):
+    # Phase 6d: examples uniqueness is on the sense-pair plus text.
+    from alarino_backend.db_models import Sense
+
     yoruba = Word(language="yo", word="ile")
     english = Word(language="en", word="house")
     db.session.add_all([yoruba, english])
     db.session.flush()
-    translation = Translation(
-        source_word_id=yoruba.w_id, target_word_id=english.w_id
-    )
-    db.session.add(translation)
+    yo_sense = Sense(word_id=yoruba.w_id)
+    en_sense = Sense(word_id=english.w_id)
+    db.session.add_all([yo_sense, en_sense])
     db.session.flush()
 
     db.session.add(
         Example(
-            translation_id=translation.t_id,
-            example_source="ile mi",
-            example_target="my house",
+            source_sense_id=en_sense.sense_id,
+            target_sense_id=yo_sense.sense_id,
+            example_source="hello there",
+            example_target="bawo nibe",
         )
     )
     db.session.commit()
 
     db.session.add(
         Example(
-            translation_id=translation.t_id,
-            example_source="ile mi",
-            example_target="my house",
+            source_sense_id=en_sense.sense_id,
+            target_sense_id=yo_sense.sense_id,
+            example_source="hello there",
+            example_target="bawo nibe",
         )
     )
     with pytest.raises(IntegrityError):

--- a/alarino_backend/tests/test_normalization.py
+++ b/alarino_backend/tests/test_normalization.py
@@ -1,0 +1,147 @@
+"""End-to-end tests for Yoruba/English text normalization across every write
+and read path that touches the database. The codebase has historically had
+inconsistent normalization between writers and readers; these tests guard
+against regressions in any single path falling out of sync."""
+
+import unicodedata
+
+import pytest
+
+import alarino_backend.app as app_module
+import alarino_backend.translation_service as translation_service
+from alarino_backend import db
+from alarino_backend.data.seed_data_utils import (
+    add_proverb,
+    add_word,
+    is_valid_english_word,
+    is_valid_yoruba_text,
+    is_valid_yoruba_word,
+    normalize_text,
+    normalize_word_text,
+)
+from alarino_backend.db_models import MissingTranslation, Proverb, Word
+from alarino_backend.languages import Language
+
+
+# Yoruba "ọmọ" — exercises the precomposed/decomposed split.
+NFC_OMO = unicodedata.normalize("NFC", "ọmọ")
+NFD_OMO = unicodedata.normalize("NFD", "ọmọ")
+
+
+@pytest.fixture
+def db_app():
+    app = app_module.create_app()
+    app.config["TESTING"] = True
+    with app.app_context():
+        db.create_all()
+        try:
+            yield app
+        finally:
+            db.session.remove()
+            db.drop_all()
+
+
+def test_canonical_yoruba_forms_differ_at_byte_level():
+    # Sanity: the rest of these tests only mean something if NFC and NFD
+    # of the same Yoruba word actually have different codepoints.
+    assert NFC_OMO != NFD_OMO
+
+
+def test_normalize_word_text_collapses_nfc_and_nfd():
+    assert normalize_word_text(NFC_OMO) == normalize_word_text(NFD_OMO)
+    assert normalize_word_text(NFC_OMO) == NFC_OMO
+
+
+def test_normalize_text_collapses_nfc_and_nfd_preserving_case():
+    assert normalize_text(f"  {NFD_OMO}  ") == NFC_OMO
+    # Case is preserved at sentence level (unlike normalize_word_text).
+    assert normalize_text("Hello World") == "Hello World"
+
+
+def test_is_valid_yoruba_word_accepts_decomposed_input():
+    # Pre-fix bug: the regex char class was NFC but the input was checked
+    # in whatever form the caller passed, so NFD Yoruba was rejected.
+    assert is_valid_yoruba_word(NFC_OMO) is True
+    assert is_valid_yoruba_word(NFD_OMO) is True
+
+
+def test_is_valid_yoruba_text_accepts_decomposed_input():
+    assert is_valid_yoruba_text(f"{NFD_OMO} mi") is True
+
+
+def test_is_valid_english_word_handles_combining_marks_gracefully():
+    # ASCII English is invariant under NFC/NFD, but the validator should not
+    # blow up on stray combining marks in input.
+    assert is_valid_english_word("hello") is True
+
+
+def test_add_word_stores_nfc_regardless_of_input_form(db_app):
+    add_word(language=Language.YORUBA, word_text=NFD_OMO)
+    db.session.commit()
+
+    rows = Word.query.filter_by(language=Language.YORUBA).all()
+    assert [row.word for row in rows] == [NFC_OMO]
+
+
+def test_add_word_collapses_nfd_and_nfc_to_one_row(db_app):
+    add_word(language=Language.YORUBA, word_text=NFC_OMO)
+    add_word(language=Language.YORUBA, word_text=NFD_OMO)
+    db.session.commit()
+
+    assert Word.query.filter_by(language=Language.YORUBA).count() == 1
+
+
+def test_add_proverb_stores_nfc_regardless_of_input_form(db_app):
+    add_proverb(f"{NFD_OMO} mi", "my child")
+    db.session.commit()
+
+    proverb = Proverb.query.one()
+    assert proverb.yoruba_text == f"{NFC_OMO} mi"
+
+
+def test_add_proverb_treats_nfc_and_nfd_as_same_proverb(db_app):
+    add_proverb(f"{NFC_OMO} mi", "my child")
+    add_proverb(f"{NFD_OMO} mi", "my child")
+    db.session.commit()
+
+    # Both inserts must collapse to one row; the second should be detected
+    # as an existing proverb after normalization, not insert a near-duplicate.
+    assert Proverb.query.count() == 1
+
+
+def test_translate_finds_word_when_query_uses_decomposed_form(db_app):
+    # Seed a Word in NFC form (storage canonical).
+    add_word(language=Language.YORUBA, word_text=NFC_OMO)
+    english_word = add_word(language=Language.ENGLISH, word_text="child")
+    db.session.flush()
+    from alarino_backend.db_models import Translation
+    yoruba_word = Word.query.filter_by(language=Language.YORUBA).one()
+    db.session.add(
+        Translation(
+            source_word_id=yoruba_word.w_id, target_word_id=english_word.w_id
+        )
+    )
+    db.session.commit()
+
+    response, status = translation_service.translate(
+        db, NFD_OMO, Language.YORUBA, Language.ENGLISH, "pytest-agent"
+    )
+    assert status == 200
+    assert response["data"]["translation"] == ["child"]
+
+
+def test_log_missing_translation_collapses_nfc_nfd_in_request_path(db_app):
+    # Two requests, same Yoruba word in different normalization forms,
+    # against an empty words table. Should produce ONE missing_translations
+    # row with hit_count=2, not two separate rows.
+    translation_service.translate(
+        db, NFC_OMO, Language.YORUBA, Language.ENGLISH, "pytest-agent"
+    )
+    translation_service.translate(
+        db, NFD_OMO, Language.YORUBA, Language.ENGLISH, "pytest-agent"
+    )
+
+    rows = MissingTranslation.query.all()
+    assert len(rows) == 1
+    assert rows[0].text == NFC_OMO
+    assert rows[0].hit_count == 2

--- a/alarino_backend/tests/test_normalization.py
+++ b/alarino_backend/tests/test_normalization.py
@@ -80,7 +80,7 @@ def test_add_word_stores_nfc_regardless_of_input_form(db_app):
     db.session.commit()
 
     rows = Word.query.filter_by(language=Language.YORUBA).all()
-    assert [row.word for row in rows] == [NFC_OMO]
+    assert [row.text for row in rows] == [NFC_OMO]
 
 
 def test_add_word_collapses_nfd_and_nfc_to_one_row(db_app):

--- a/alarino_backend/tests/test_normalization.py
+++ b/alarino_backend/tests/test_normalization.py
@@ -110,17 +110,14 @@ def test_add_proverb_treats_nfc_and_nfd_as_same_proverb(db_app):
 
 
 def test_translate_finds_word_when_query_uses_decomposed_form(db_app):
+    from alarino_backend.data.seed_data_utils import create_translation
+
     # Seed a Word in NFC form (storage canonical).
     add_word(language=Language.YORUBA, word_text=NFC_OMO)
     english_word = add_word(language=Language.ENGLISH, word_text="child")
     db.session.flush()
-    from alarino_backend.db_models import Translation
     yoruba_word = Word.query.filter_by(language=Language.YORUBA).one()
-    db.session.add(
-        Translation(
-            source_word_id=yoruba_word.w_id, target_word_id=english_word.w_id
-        )
-    )
+    create_translation(yoruba_word, english_word)
     db.session.commit()
 
     response, status = translation_service.translate(

--- a/alarino_backend/tests/test_normalization_defenses.py
+++ b/alarino_backend/tests/test_normalization_defenses.py
@@ -48,8 +48,8 @@ def db_app():
 # ---- TypeDecorators are wired onto the right columns ----
 
 
-def test_word_word_column_uses_nfcword():
-    assert isinstance(Word.__table__.c.word.type, NFCWord)
+def test_word_text_column_uses_nfcword():
+    assert isinstance(Word.__table__.c.text.type, NFCWord)
 
 
 def test_missing_translation_text_column_uses_nfcword():
@@ -68,14 +68,14 @@ def test_nfcword_normalizes_on_bind_without_explicit_normalize_call(db_app):
     # Bypass the explicit add_word() pre-normalization. Construct Word
     # directly with NFD input. The NFCWord TypeDecorator must convert it
     # to NFC at SQL bind time.
-    db.session.add(Word(language="yo", word=NFD_OMO))
+    db.session.add(Word(language="yo", text=NFD_OMO))
     db.session.commit()
 
     stored = Word.query.filter_by(language="yo").one()
-    assert stored.word == NFC_OMO
+    assert stored.text == NFC_OMO
     # And byte-level: the stored value must match NFC bytes, not NFD bytes.
-    assert stored.word.encode() == NFC_OMO.encode()
-    assert stored.word.encode() != NFD_OMO.encode()
+    assert stored.text.encode() == NFC_OMO.encode()
+    assert stored.text.encode() != NFD_OMO.encode()
 
 
 def test_nfctext_normalizes_on_bind_without_explicit_normalize_call(db_app):
@@ -95,12 +95,12 @@ def test_nfcword_normalizes_on_query_parameters_too(db_app):
     # Storage is NFC. Query with NFD input. The NFCWord type normalizes
     # parameters at bind time, so the WHERE clause sees NFC bytes and
     # finds the row.
-    db.session.add(Word(language="yo", word=NFC_OMO))
+    db.session.add(Word(language="yo", text=NFC_OMO))
     db.session.commit()
 
-    found = Word.query.filter_by(word=NFD_OMO).first()
+    found = Word.query.filter_by(text=NFD_OMO).first()
     assert found is not None
-    assert found.word == NFC_OMO
+    assert found.text == NFC_OMO
 
 
 # ---- audit_normalization_integrity ----
@@ -108,8 +108,8 @@ def test_nfcword_normalizes_on_query_parameters_too(db_app):
 
 def test_audit_returns_empty_dict_for_clean_db(db_app):
     db.session.add_all([
-        Word(language="yo", word="ile"),
-        Word(language="en", word="house"),
+        Word(language="yo", text="ile"),
+        Word(language="en", text="house"),
         Proverb(yoruba_text="ile mi", english_text="my house"),
         MissingTranslation(
             text="hello",
@@ -127,21 +127,22 @@ def test_audit_detects_smuggled_nfd_in_words(db_app):
     # Bypass both the TypeDecorator (which normalizes on bind) and the
     # service helpers, by using a raw SQL INSERT that the DBAPI driver
     # writes verbatim. The audit must report the violation.
-    db.session.add(Word(language="yo", word="dummy"))  # placeholder so table exists
+    db.session.add(Word(language="yo", text="dummy"))  # placeholder so table exists
     db.session.commit()
 
     db.session.execute(
-        db.text("INSERT INTO words (language, word) VALUES (:lang, :word)"),
-        {"lang": "yo", "word": NFD_OMO},
+        db.text("INSERT INTO words (language, text) VALUES (:lang, :text_val)"),
+        {"lang": "yo", "text_val": NFD_OMO},
     )
     db.session.commit()
 
     smuggled_w_id = db.session.execute(
-        db.text("SELECT w_id FROM words WHERE word = :w"), {"w": NFD_OMO}
+        db.text("SELECT w_id FROM words WHERE text = :text_val"),
+        {"text_val": NFD_OMO},
     ).scalar()
 
     violations = audit_normalization_integrity(db)
-    assert violations == {"words.word": [smuggled_w_id]}
+    assert violations == {"words.text": [smuggled_w_id]}
 
 
 def test_audit_detects_smuggled_nfd_in_proverb_columns(db_app):

--- a/alarino_backend/tests/test_normalization_defenses.py
+++ b/alarino_backend/tests/test_normalization_defenses.py
@@ -1,0 +1,162 @@
+"""Phase 3b — TypeDecorator + integrity-audit defenses.
+
+These tests guard the *structural* normalization defense (the NFCWord and
+NFCText TypeDecorators on canonical text columns) and the
+``audit_normalization_integrity`` smoke check. They complement the per-path
+property tests in ``test_normalization.py`` (which exercise every API
+surface with NFC and NFD inputs); the tests here specifically prove that
+the column type itself does the work, even when the call site bypasses
+the explicit ``normalize_word_text`` helper."""
+
+import unicodedata
+
+import pytest
+
+import alarino_backend.app as app_module
+from alarino_backend import db
+from alarino_backend.db_models import (
+    MissingTranslation,
+    NFCText,
+    NFCWord,
+    Proverb,
+    Word,
+)
+from alarino_backend.normalization import (
+    audit_normalization_integrity,
+    normalize_text,
+    normalize_word_text,
+)
+
+
+NFC_OMO = unicodedata.normalize("NFC", "ọmọ")
+NFD_OMO = unicodedata.normalize("NFD", "ọmọ")
+
+
+@pytest.fixture
+def db_app():
+    app = app_module.create_app()
+    app.config["TESTING"] = True
+    with app.app_context():
+        db.create_all()
+        try:
+            yield app
+        finally:
+            db.session.remove()
+            db.drop_all()
+
+
+# ---- TypeDecorators are wired onto the right columns ----
+
+
+def test_word_word_column_uses_nfcword():
+    assert isinstance(Word.__table__.c.word.type, NFCWord)
+
+
+def test_missing_translation_text_column_uses_nfcword():
+    assert isinstance(MissingTranslation.__table__.c.text.type, NFCWord)
+
+
+def test_proverb_text_columns_use_nfctext():
+    assert isinstance(Proverb.__table__.c.yoruba_text.type, NFCText)
+    assert isinstance(Proverb.__table__.c.english_text.type, NFCText)
+
+
+# ---- TypeDecorators normalize on bind even when the call site does not ----
+
+
+def test_nfcword_normalizes_on_bind_without_explicit_normalize_call(db_app):
+    # Bypass the explicit add_word() pre-normalization. Construct Word
+    # directly with NFD input. The NFCWord TypeDecorator must convert it
+    # to NFC at SQL bind time.
+    db.session.add(Word(language="yo", word=NFD_OMO))
+    db.session.commit()
+
+    stored = Word.query.filter_by(language="yo").one()
+    assert stored.word == NFC_OMO
+    # And byte-level: the stored value must match NFC bytes, not NFD bytes.
+    assert stored.word.encode() == NFC_OMO.encode()
+    assert stored.word.encode() != NFD_OMO.encode()
+
+
+def test_nfctext_normalizes_on_bind_without_explicit_normalize_call(db_app):
+    # Bypass add_proverb()'s pre-normalization. Construct Proverb directly
+    # with NFD inputs. The NFCText TypeDecorator must convert.
+    db.session.add(
+        Proverb(yoruba_text=f"  {NFD_OMO} mi  ", english_text="  my child  ")
+    )
+    db.session.commit()
+
+    p = Proverb.query.one()
+    assert p.yoruba_text == f"{NFC_OMO} mi"
+    assert p.english_text == "my child"
+
+
+def test_nfcword_normalizes_on_query_parameters_too(db_app):
+    # Storage is NFC. Query with NFD input. The NFCWord type normalizes
+    # parameters at bind time, so the WHERE clause sees NFC bytes and
+    # finds the row.
+    db.session.add(Word(language="yo", word=NFC_OMO))
+    db.session.commit()
+
+    found = Word.query.filter_by(word=NFD_OMO).first()
+    assert found is not None
+    assert found.word == NFC_OMO
+
+
+# ---- audit_normalization_integrity ----
+
+
+def test_audit_returns_empty_dict_for_clean_db(db_app):
+    db.session.add_all([
+        Word(language="yo", word="ile"),
+        Word(language="en", word="house"),
+        Proverb(yoruba_text="ile mi", english_text="my house"),
+        MissingTranslation(
+            text="hello",
+            source_language="en",
+            target_language="yo",
+            user_agent="pytest",
+        ),
+    ])
+    db.session.commit()
+
+    assert audit_normalization_integrity(db) == {}
+
+
+def test_audit_detects_smuggled_nfd_in_words(db_app):
+    # Bypass both the TypeDecorator (which normalizes on bind) and the
+    # service helpers, by using a raw SQL INSERT that the DBAPI driver
+    # writes verbatim. The audit must report the violation.
+    db.session.add(Word(language="yo", word="dummy"))  # placeholder so table exists
+    db.session.commit()
+
+    db.session.execute(
+        db.text("INSERT INTO words (language, word) VALUES (:lang, :word)"),
+        {"lang": "yo", "word": NFD_OMO},
+    )
+    db.session.commit()
+
+    smuggled_w_id = db.session.execute(
+        db.text("SELECT w_id FROM words WHERE word = :w"), {"w": NFD_OMO}
+    ).scalar()
+
+    violations = audit_normalization_integrity(db)
+    assert violations == {"words.word": [smuggled_w_id]}
+
+
+def test_audit_detects_smuggled_nfd_in_proverb_columns(db_app):
+    db.session.execute(
+        db.text(
+            "INSERT INTO proverbs (yoruba_text, english_text) "
+            "VALUES (:y, :e)"
+        ),
+        {"y": NFD_OMO + " mi", "e": "  my child  "},
+    )
+    db.session.commit()
+
+    p_id = db.session.execute(db.text("SELECT p_id FROM proverbs")).scalar()
+    violations = audit_normalization_integrity(db)
+    assert "proverbs.yoruba_text" in violations
+    assert "proverbs.english_text" in violations
+    assert violations["proverbs.yoruba_text"] == [p_id]
+    assert violations["proverbs.english_text"] == [p_id]

--- a/alarino_backend/tests/test_parts_of_speech.py
+++ b/alarino_backend/tests/test_parts_of_speech.py
@@ -1,5 +1,8 @@
-"""Tests for the PartOfSpeech enum + CHECK constraints (Phase 6b POS-check
-sub-phase, revision c4b8e1a5d927)."""
+"""Tests for the PartOfSpeech enum + CHECK constraint on Sense.part_of_speech.
+
+Phase 6b POS-check (revision c4b8e1a5d927) added CHECK constraints on both
+Word.part_of_speech and Sense.part_of_speech. Phase 6d (d8a3f0b71e5c)
+dropped Word.part_of_speech entirely — POS lives only on Sense now."""
 
 import pytest
 from sqlalchemy.exc import IntegrityError
@@ -40,34 +43,20 @@ def test_part_of_speech_str_returns_short_code():
     assert str(PartOfSpeech.INTERJECTION) == "interj"
 
 
+def test_word_no_longer_has_part_of_speech_column():
+    # Phase 6d removed it. Set POS on the Sense instead.
+    assert "part_of_speech" not in {c.name for c in Word.__table__.columns}
+
+
 @pytest.mark.parametrize("pos", list(PartOfSpeech))
-def test_word_check_constraint_accepts_every_canonical_pos_value(db_app, pos):
-    # Construct via model (not add_word) to bypass the Yoruba char-set
-    # validator — we're exercising the DB-level CHECK constraint here.
-    db.session.add(Word(language="yo", word=f"w-{pos.value}", part_of_speech=pos.value))
+def test_sense_check_constraint_accepts_every_canonical_pos_value(db_app, pos):
+    word = Word(language="yo", word=f"w-{pos.value}")
+    db.session.add(word)
+    db.session.flush()
+    db.session.add(Sense(word_id=word.w_id, part_of_speech=pos.value))
     db.session.commit()
-    stored = Word.query.filter_by(word=f"w-{pos.value}").one()
+    stored = Sense.query.filter_by(word_id=word.w_id).one()
     assert stored.part_of_speech == pos.value
-
-
-def test_word_accepts_null_part_of_speech(db_app):
-    add_word(language=Language.YORUBA, word_text="ile")
-    db.session.commit()
-    assert Word.query.filter_by(word="ile").one().part_of_speech is None
-
-
-def test_add_word_persists_part_of_speech_enum(db_app):
-    # Sanity that the seed_data_utils path forwards the enum value.
-    add_word(language=Language.YORUBA, word_text="ile", part_of_speech=PartOfSpeech.NOUN)
-    db.session.commit()
-    assert Word.query.filter_by(word="ile").one().part_of_speech == "n"
-
-
-def test_word_check_constraint_rejects_non_canonical_pos(db_app):
-    db.session.add(Word(language="yo", word="ile", part_of_speech="Noun"))
-    with pytest.raises(IntegrityError):
-        db.session.commit()
-    db.session.rollback()
 
 
 def test_sense_check_constraint_rejects_non_canonical_pos(db_app):
@@ -87,3 +76,10 @@ def test_sense_accepts_null_part_of_speech(db_app):
     db.session.add(Sense(word_id=word.w_id))
     db.session.commit()
     assert Sense.query.one().part_of_speech is None
+
+
+def test_add_word_no_longer_takes_part_of_speech_kwarg():
+    # Sanity: passing part_of_speech to add_word should be a TypeError now.
+    # POS is sense-scoped post-Phase-6d.
+    with pytest.raises(TypeError):
+        add_word(language=Language.YORUBA, word_text="ile", part_of_speech=PartOfSpeech.NOUN)

--- a/alarino_backend/tests/test_parts_of_speech.py
+++ b/alarino_backend/tests/test_parts_of_speech.py
@@ -50,7 +50,7 @@ def test_word_no_longer_has_part_of_speech_column():
 
 @pytest.mark.parametrize("pos", list(PartOfSpeech))
 def test_sense_check_constraint_accepts_every_canonical_pos_value(db_app, pos):
-    word = Word(language="yo", word=f"w-{pos.value}")
+    word = Word(language="yo", text=f"w-{pos.value}")
     db.session.add(word)
     db.session.flush()
     db.session.add(Sense(word_id=word.w_id, part_of_speech=pos.value))
@@ -60,7 +60,7 @@ def test_sense_check_constraint_accepts_every_canonical_pos_value(db_app, pos):
 
 
 def test_sense_check_constraint_rejects_non_canonical_pos(db_app):
-    word = Word(language="yo", word="ile")
+    word = Word(language="yo", text="ile")
     db.session.add(word)
     db.session.flush()
     db.session.add(Sense(word_id=word.w_id, part_of_speech="bogus_pos"))
@@ -70,7 +70,7 @@ def test_sense_check_constraint_rejects_non_canonical_pos(db_app):
 
 
 def test_sense_accepts_null_part_of_speech(db_app):
-    word = Word(language="yo", word="ile")
+    word = Word(language="yo", text="ile")
     db.session.add(word)
     db.session.flush()
     db.session.add(Sense(word_id=word.w_id))

--- a/alarino_backend/tests/test_parts_of_speech.py
+++ b/alarino_backend/tests/test_parts_of_speech.py
@@ -1,0 +1,89 @@
+"""Tests for the PartOfSpeech enum + CHECK constraints (Phase 6b POS-check
+sub-phase, revision c4b8e1a5d927)."""
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+import alarino_backend.app as app_module
+from alarino_backend import db
+from alarino_backend.data.seed_data_utils import add_word
+from alarino_backend.db_models import Sense, Word
+from alarino_backend.languages import Language
+from alarino_backend.parts_of_speech import ALLOWED_POS_VALUES, PartOfSpeech
+
+
+@pytest.fixture
+def db_app():
+    app = app_module.create_app()
+    app.config["TESTING"] = True
+    with app.app_context():
+        db.create_all()
+        try:
+            yield app
+        finally:
+            db.session.remove()
+            db.drop_all()
+
+
+def test_allowed_pos_values_includes_all_enum_codes():
+    enum_values = {p.value for p in PartOfSpeech}
+    assert set(ALLOWED_POS_VALUES) == enum_values
+
+
+def test_allowed_pos_values_is_sorted():
+    # Sorted for stable CHECK-constraint SQL across migrations.
+    assert list(ALLOWED_POS_VALUES) == sorted(ALLOWED_POS_VALUES)
+
+
+def test_part_of_speech_str_returns_short_code():
+    assert str(PartOfSpeech.NOUN) == "n"
+    assert str(PartOfSpeech.INTERJECTION) == "interj"
+
+
+@pytest.mark.parametrize("pos", list(PartOfSpeech))
+def test_word_check_constraint_accepts_every_canonical_pos_value(db_app, pos):
+    # Construct via model (not add_word) to bypass the Yoruba char-set
+    # validator — we're exercising the DB-level CHECK constraint here.
+    db.session.add(Word(language="yo", word=f"w-{pos.value}", part_of_speech=pos.value))
+    db.session.commit()
+    stored = Word.query.filter_by(word=f"w-{pos.value}").one()
+    assert stored.part_of_speech == pos.value
+
+
+def test_word_accepts_null_part_of_speech(db_app):
+    add_word(language=Language.YORUBA, word_text="ile")
+    db.session.commit()
+    assert Word.query.filter_by(word="ile").one().part_of_speech is None
+
+
+def test_add_word_persists_part_of_speech_enum(db_app):
+    # Sanity that the seed_data_utils path forwards the enum value.
+    add_word(language=Language.YORUBA, word_text="ile", part_of_speech=PartOfSpeech.NOUN)
+    db.session.commit()
+    assert Word.query.filter_by(word="ile").one().part_of_speech == "n"
+
+
+def test_word_check_constraint_rejects_non_canonical_pos(db_app):
+    db.session.add(Word(language="yo", word="ile", part_of_speech="Noun"))
+    with pytest.raises(IntegrityError):
+        db.session.commit()
+    db.session.rollback()
+
+
+def test_sense_check_constraint_rejects_non_canonical_pos(db_app):
+    word = Word(language="yo", word="ile")
+    db.session.add(word)
+    db.session.flush()
+    db.session.add(Sense(word_id=word.w_id, part_of_speech="bogus_pos"))
+    with pytest.raises(IntegrityError):
+        db.session.commit()
+    db.session.rollback()
+
+
+def test_sense_accepts_null_part_of_speech(db_app):
+    word = Word(language="yo", word="ile")
+    db.session.add(word)
+    db.session.flush()
+    db.session.add(Sense(word_id=word.w_id))
+    db.session.commit()
+    assert Sense.query.one().part_of_speech is None

--- a/alarino_backend/tests/test_proverb_words.py
+++ b/alarino_backend/tests/test_proverb_words.py
@@ -1,0 +1,98 @@
+"""Tests for the proverb-words connection introduced by Phase 3 of the schema
+evolution plan."""
+
+import pytest
+
+import alarino_backend.app as app_module
+import alarino_backend.translation_service as translation_service
+from alarino_backend import db
+from alarino_backend.data.seed_data_utils import add_proverb
+from alarino_backend.db_models import Proverb, ProverbWord, Word
+from alarino_backend.languages import Language
+
+
+@pytest.fixture
+def db_app():
+    app = app_module.create_app()
+    app.config["TESTING"] = True
+    with app.app_context():
+        db.create_all()
+        try:
+            yield app
+        finally:
+            db.session.remove()
+            db.drop_all()
+
+
+def test_add_proverb_populates_proverb_words(db_app):
+    add_proverb("ile mi", "my house")
+
+    proverb = Proverb.query.one()
+    links = ProverbWord.query.filter_by(proverb_id=proverb.p_id).all()
+    yoruba_links = [link for link in links if link.language == "yo"]
+    english_links = [link for link in links if link.language == "en"]
+
+    yoruba_words = {link.word.word for link in yoruba_links}
+    english_words = {link.word.word for link in english_links}
+    assert yoruba_words == {"ile", "mi"}
+    assert english_words == {"my", "house"}
+
+
+def test_get_proverbs_containing_returns_matching_proverb(db_app):
+    add_proverb("ile mi", "my house")
+    add_proverb("omi tutu", "cool water")
+
+    matching = translation_service.get_proverbs_containing(
+        db, Language.YORUBA, "ile"
+    )
+    assert {p.yoruba_text for p in matching} == {"ile mi"}
+
+    matching_en = translation_service.get_proverbs_containing(
+        db, Language.ENGLISH, "house"
+    )
+    assert {p.english_text for p in matching_en} == {"my house"}
+
+
+def test_get_proverbs_containing_returns_empty_for_unknown_word(db_app):
+    add_proverb("ile mi", "my house")
+
+    assert translation_service.get_proverbs_containing(
+        db, Language.YORUBA, "missing"
+    ) == []
+    assert translation_service.get_proverbs_containing(
+        db, Language.YORUBA, ""
+    ) == []
+
+
+def test_get_proverbs_containing_normalizes_decomposed_input(db_app):
+    # Yoruba "ọmọ" stored canonically (NFC). Querying with the same string in
+    # NFD form (the ọ becomes 'o' + COMBINING DOT BELOW) must match.
+    add_proverb("ọmọ mi", "my child")
+
+    import unicodedata
+
+    decomposed_query = unicodedata.normalize("NFD", "ọmọ")
+    assert decomposed_query != "ọmọ"  # sanity: forms really differ
+
+    matching = translation_service.get_proverbs_containing(
+        db, Language.YORUBA, decomposed_query
+    )
+    assert {p.yoruba_text for p in matching} == {"ọmọ mi"}
+
+
+def test_repeated_word_in_proverb_gets_distinct_position(db_app):
+    add_proverb("ile ile mi", "house house mine")
+
+    proverb = Proverb.query.one()
+    yoruba_ile = (
+        ProverbWord.query
+        .join(Word, Word.w_id == ProverbWord.word_id)
+        .filter(
+            ProverbWord.proverb_id == proverb.p_id,
+            ProverbWord.language == "yo",
+            Word.word == "ile",
+        )
+        .all()
+    )
+    positions = sorted(link.position for link in yoruba_ile)
+    assert positions == [0, 1]

--- a/alarino_backend/tests/test_proverb_words.py
+++ b/alarino_backend/tests/test_proverb_words.py
@@ -32,8 +32,8 @@ def test_add_proverb_populates_proverb_words(db_app):
     yoruba_links = [link for link in links if link.language == "yo"]
     english_links = [link for link in links if link.language == "en"]
 
-    yoruba_words = {link.word.word for link in yoruba_links}
-    english_words = {link.word.word for link in english_links}
+    yoruba_words = {link.word.text for link in yoruba_links}
+    english_words = {link.word.text for link in english_links}
     assert yoruba_words == {"ile", "mi"}
     assert english_words == {"my", "house"}
 
@@ -90,7 +90,7 @@ def test_repeated_word_in_proverb_gets_distinct_position(db_app):
         .filter(
             ProverbWord.proverb_id == proverb.p_id,
             ProverbWord.language == "yo",
-            Word.word == "ile",
+            Word.text == "ile",
         )
         .all()
     )

--- a/alarino_backend/tests/test_sense_layer.py
+++ b/alarino_backend/tests/test_sense_layer.py
@@ -323,6 +323,127 @@ def test_create_translation_reuses_existing_default_sense(db_app):
     assert Sense.query.filter_by(word_id=en.w_id).count() == 1
 
 
+# ---- Phase 7 bug-fix: polysemy + ambiguous-sense regression tests ----
+
+
+def test_translation_uniqueness_is_on_sense_pair_not_word_pair(db_app):
+    # P1b regression test: the original Phase 6 cutover left
+    # unique_translation_pair on (source_word_id, target_word_id), which
+    # blocked exactly the polysemy use case the sense layer is supposed to
+    # unlock. After the Phase 7 bug-fix, two translations for the same
+    # word pair but different sense pairs must coexist.
+    from alarino_backend.db_models import Translation
+
+    bank = add_word(language=Language.ENGLISH, word_text="bank")
+    edge = add_word(language=Language.YORUBA, word_text="eti")
+    db.session.flush()
+
+    fin = Sense(word_id=bank.w_id, sense_label="financial")
+    riv = Sense(word_id=bank.w_id, sense_label="river")
+    edge_fin = Sense(word_id=edge.w_id, sense_label="financial-edge")
+    edge_riv = Sense(word_id=edge.w_id, sense_label="river-edge")
+    db.session.add_all([fin, riv, edge_fin, edge_riv])
+    db.session.flush()
+
+    db.session.add_all([
+        Translation(
+            source_word_id=bank.w_id, target_word_id=edge.w_id,
+            source_sense_id=fin.sense_id, target_sense_id=edge_fin.sense_id,
+        ),
+        Translation(
+            source_word_id=bank.w_id, target_word_id=edge.w_id,
+            source_sense_id=riv.sense_id, target_sense_id=edge_riv.sense_id,
+        ),
+    ])
+    db.session.commit()  # must not raise
+
+    assert Translation.query.count() == 2
+
+
+def test_translation_sense_pair_uniqueness_still_rejects_duplicate_pair(db_app):
+    from sqlalchemy.exc import IntegrityError
+    from alarino_backend.db_models import Translation
+
+    en = add_word(language=Language.ENGLISH, word_text="hello")
+    yo = add_word(language=Language.YORUBA, word_text="bawo")
+    db.session.flush()
+    en_sense = Sense(word_id=en.w_id)
+    yo_sense = Sense(word_id=yo.w_id)
+    db.session.add_all([en_sense, yo_sense])
+    db.session.flush()
+
+    db.session.add(Translation(
+        source_word_id=en.w_id, target_word_id=yo.w_id,
+        source_sense_id=en_sense.sense_id, target_sense_id=yo_sense.sense_id,
+    ))
+    db.session.commit()
+
+    db.session.add(Translation(
+        source_word_id=en.w_id, target_word_id=yo.w_id,
+        source_sense_id=en_sense.sense_id, target_sense_id=yo_sense.sense_id,
+    ))
+    with pytest.raises(IntegrityError):
+        db.session.commit()
+    db.session.rollback()
+
+
+def test_create_translation_raises_on_multi_sense_source_word(db_app):
+    # P2 regression test: previously create_translation silently bound a
+    # new translation to whichever sense had the lowest sense_id when the
+    # word had multiple curated senses. After the Phase 7 bug-fix, this
+    # must raise AmbiguousSenseError so callers either pick a sense
+    # explicitly or surface the ambiguity.
+    from alarino_backend.data.seed_data_utils import AmbiguousSenseError
+
+    bank = add_word(language=Language.ENGLISH, word_text="bank")
+    yo_word = add_word(language=Language.YORUBA, word_text="ifowopamo")
+    db.session.flush()
+    db.session.add_all([
+        Sense(word_id=bank.w_id, sense_label="financial"),
+        Sense(word_id=bank.w_id, sense_label="river"),
+    ])
+    db.session.commit()
+
+    with pytest.raises(AmbiguousSenseError) as excinfo:
+        create_translation(bank, yo_word)
+    # The message must name the ambiguous word so the operator can find it.
+    assert "bank" in str(excinfo.value)
+    assert "2 senses" in str(excinfo.value)
+
+
+def test_create_translation_raises_on_multi_sense_target_word(db_app):
+    # Symmetry: the source-side check above also applies to the target side.
+    from alarino_backend.data.seed_data_utils import AmbiguousSenseError
+
+    en_word = add_word(language=Language.ENGLISH, word_text="bank")
+    polysemous_yo = add_word(language=Language.YORUBA, word_text="bebe")
+    db.session.flush()
+    db.session.add_all([
+        Sense(word_id=polysemous_yo.w_id, sense_label="edge"),
+        Sense(word_id=polysemous_yo.w_id, sense_label="boundary"),
+    ])
+    db.session.commit()
+
+    with pytest.raises(AmbiguousSenseError):
+        create_translation(en_word, polysemous_yo)
+
+
+def test_create_translation_is_idempotent_on_sense_pair(db_app):
+    # Existence check moved from word-pair to sense-pair in the Phase 7
+    # bug-fix. Calling create_translation twice with the same words (and
+    # therefore the same default senses) must remain a no-op.
+    en = add_word(language=Language.ENGLISH, word_text="hello")
+    yo = add_word(language=Language.YORUBA, word_text="bawo")
+    db.session.flush()
+
+    create_translation(en, yo)
+    db.session.commit()
+    create_translation(en, yo)
+    db.session.commit()
+
+    assert Translation.query.count() == 1
+
+
 def test_sense_word_id_fk_uses_db_level_cascade(db_app):
     # The model declares ondelete='CASCADE' on senses.word_id. Verify the
     # constraint is wired at the DB level via a raw SQL DELETE (bypassing

--- a/alarino_backend/tests/test_sense_layer.py
+++ b/alarino_backend/tests/test_sense_layer.py
@@ -1,16 +1,24 @@
-"""Tests for Phase 6a — additive sense-layer scaffolding.
+"""Tests for Phase 6a/6b — sense-layer scaffolding and write-path cutover.
 
-Phase 6a only adds: the senses table, four new columns on translations
-(source_sense_id, target_sense_id, note, confidence, provenance), and
-a backfill that creates one Sense per existing Word and links existing
-Translations to those senses. No reads or writes change behavior.
-Phases 6b/6c/6d build on this foundation."""
+Phase 6a (additive only) adds the senses table, sense FKs and metadata
+columns on translations, and backfills one Sense per Word.
+
+Phase 6b adds source_sense_id and target_sense_id columns to examples
+(backfilled from the parent Translation) and updates the create_translation
+write path so every new Translation has its sense FKs populated.
+
+Phases 6c (read cutover, API change) and 6d (drop legacy) build on these."""
 
 import pytest
 
 import alarino_backend.app as app_module
 from alarino_backend import db
-from alarino_backend.db_models import Sense, Translation, Word
+from alarino_backend.data.seed_data_utils import (
+    add_word,
+    create_translation,
+)
+from alarino_backend.db_models import Example, Sense, Translation, Word
+from alarino_backend.languages import Language
 
 
 @pytest.fixture
@@ -137,6 +145,63 @@ def test_translation_can_carry_metadata(db_app):
     assert t.note.startswith("informal greeting")
     assert t.confidence == 0.95
     assert t.provenance == "curated"
+
+
+# ---- Phase 6b: write-path cutover + Example sense columns ----
+
+
+def test_example_has_sense_fk_columns():
+    columns = {c.name for c in Example.__table__.columns}
+    assert "source_sense_id" in columns
+    assert "target_sense_id" in columns
+
+
+def test_example_translation_id_still_present_in_phase_6b():
+    # Phase 6b keeps translation_id on Example so the legacy relationship
+    # and read paths keep working through 6c. Phase 6d drops it.
+    assert "translation_id" in {c.name for c in Example.__table__.columns}
+
+
+def test_example_sense_columns_nullable_in_phase_6b():
+    # 6b adds the columns nullable so the backfill can run incrementally.
+    # 6d tightens to NOT NULL.
+    assert Example.__table__.c.source_sense_id.nullable is True
+    assert Example.__table__.c.target_sense_id.nullable is True
+
+
+def test_create_translation_populates_sense_fks(db_app):
+    en = add_word(language=Language.ENGLISH, word_text="hello")
+    yo = add_word(language=Language.YORUBA, word_text="bawo")
+    db.session.flush()
+
+    create_translation(en, yo)
+    db.session.commit()
+
+    t = Translation.query.one()
+    assert t.source_sense_id is not None
+    assert t.target_sense_id is not None
+    # The sense FKs point at senses owned by the source/target words.
+    assert t.source_sense.word_id == en.w_id
+    assert t.target_sense.word_id == yo.w_id
+
+
+def test_create_translation_reuses_existing_default_sense(db_app):
+    en = add_word(language=Language.ENGLISH, word_text="hello")
+    yo = add_word(language=Language.YORUBA, word_text="bawo")
+    db.session.flush()
+    # Pre-create a sense for the English word; create_translation must reuse it
+    # rather than creating a duplicate "default" sense.
+    pre_existing_en_sense = Sense(word_id=en.w_id, sense_label="greeting")
+    db.session.add(pre_existing_en_sense)
+    db.session.flush()
+
+    create_translation(en, yo)
+    db.session.commit()
+
+    t = Translation.query.one()
+    assert t.source_sense_id == pre_existing_en_sense.sense_id
+    # English word should have just the one sense, not a duplicate.
+    assert Sense.query.filter_by(word_id=en.w_id).count() == 1
 
 
 def test_sense_word_id_fk_uses_db_level_cascade(db_app):

--- a/alarino_backend/tests/test_sense_layer.py
+++ b/alarino_backend/tests/test_sense_layer.py
@@ -1,0 +1,160 @@
+"""Tests for Phase 6a — additive sense-layer scaffolding.
+
+Phase 6a only adds: the senses table, four new columns on translations
+(source_sense_id, target_sense_id, note, confidence, provenance), and
+a backfill that creates one Sense per existing Word and links existing
+Translations to those senses. No reads or writes change behavior.
+Phases 6b/6c/6d build on this foundation."""
+
+import pytest
+
+import alarino_backend.app as app_module
+from alarino_backend import db
+from alarino_backend.db_models import Sense, Translation, Word
+
+
+@pytest.fixture
+def db_app():
+    app = app_module.create_app()
+    app.config["TESTING"] = True
+    with app.app_context():
+        db.create_all()
+        try:
+            yield app
+        finally:
+            db.session.remove()
+            db.drop_all()
+
+
+# ---- Model shape ----
+
+
+def test_sense_table_columns():
+    columns = {c.name for c in Sense.__table__.columns}
+    assert columns == {
+        "sense_id",
+        "word_id",
+        "part_of_speech",
+        "sense_label",
+        "definition",
+        "register",
+        "domain",
+        "created_at",
+    }
+
+
+def test_translation_has_new_metadata_columns():
+    columns = {c.name for c in Translation.__table__.columns}
+    for new_col in (
+        "source_sense_id",
+        "target_sense_id",
+        "note",
+        "confidence",
+        "provenance",
+    ):
+        assert new_col in columns, f"Translation must have new column {new_col!r}"
+
+
+def test_word_part_of_speech_still_present():
+    # Phase 6a keeps Word.part_of_speech for read-path compatibility.
+    # Phase 6d drops it after the cutover.
+    assert "part_of_speech" in {c.name for c in Word.__table__.columns}
+
+
+def test_translation_sense_fk_columns_are_nullable_in_phase_6a():
+    # Phase 6a leaves source_sense_id and target_sense_id nullable so the
+    # backfill can run incrementally and so existing write paths that
+    # don't yet set them keep working. Phase 6d makes them NOT NULL.
+    assert Translation.__table__.c.source_sense_id.nullable is True
+    assert Translation.__table__.c.target_sense_id.nullable is True
+
+
+# ---- Sense behavior under db.create_all (model-only, no migration backfill) ----
+
+
+def test_sense_can_be_created_for_a_word(db_app):
+    word = Word(language="yo", word="ile")
+    db.session.add(word)
+    db.session.flush()
+    sense = Sense(
+        word_id=word.w_id,
+        part_of_speech="n",
+        sense_label="building",
+        definition="a structure for shelter",
+        register="formal",
+        domain=None,
+    )
+    db.session.add(sense)
+    db.session.commit()
+
+    refreshed = Sense.query.one()
+    assert refreshed.word_id == word.w_id
+    assert refreshed.sense_label == "building"
+    assert refreshed.created_at is not None
+
+
+def test_word_to_senses_relationship(db_app):
+    # Word.senses backref returns a list, supporting polysemy from Phase 6b on.
+    word = Word(language="en", word="bank")
+    db.session.add(word)
+    db.session.flush()
+    db.session.add_all([
+        Sense(word_id=word.w_id, sense_label="financial"),
+        Sense(word_id=word.w_id, sense_label="river"),
+    ])
+    db.session.commit()
+
+    refreshed = Word.query.filter_by(word="bank").one()
+    assert {s.sense_label for s in refreshed.senses} == {"financial", "river"}
+
+
+def test_translation_can_carry_metadata(db_app):
+    en = Word(language="en", word="hello")
+    yo = Word(language="yo", word="bawo")
+    db.session.add_all([en, yo])
+    db.session.flush()
+    en_sense = Sense(word_id=en.w_id, sense_label="greeting")
+    yo_sense = Sense(word_id=yo.w_id, sense_label="greeting")
+    db.session.add_all([en_sense, yo_sense])
+    db.session.flush()
+
+    db.session.add(
+        Translation(
+            source_word_id=en.w_id,
+            target_word_id=yo.w_id,
+            source_sense_id=en_sense.sense_id,
+            target_sense_id=yo_sense.sense_id,
+            note="informal greeting; common in casual contexts",
+            confidence=0.95,
+            provenance="curated",
+        )
+    )
+    db.session.commit()
+
+    t = Translation.query.one()
+    assert t.source_sense_id == en_sense.sense_id
+    assert t.target_sense_id == yo_sense.sense_id
+    assert t.note.startswith("informal greeting")
+    assert t.confidence == 0.95
+    assert t.provenance == "curated"
+
+
+def test_sense_word_id_fk_uses_db_level_cascade(db_app):
+    # The model declares ondelete='CASCADE' on senses.word_id. Verify the
+    # constraint is wired at the DB level via a raw SQL DELETE (bypassing
+    # SQLAlchemy's ORM cascade, which has its own pre-delete NULL-out
+    # behavior that would interfere). On SQLite, foreign keys must be
+    # enabled per-connection.
+    word = Word(language="yo", word="ile")
+    db.session.add(word)
+    db.session.flush()
+    db.session.add(Sense(word_id=word.w_id, sense_label="building"))
+    db.session.commit()
+    assert Sense.query.count() == 1
+
+    db.session.execute(db.text("PRAGMA foreign_keys = ON"))
+    db.session.execute(
+        db.text("DELETE FROM words WHERE w_id = :id"), {"id": word.w_id}
+    )
+    db.session.commit()
+    assert Sense.query.count() == 0

--- a/alarino_backend/tests/test_sense_layer.py
+++ b/alarino_backend/tests/test_sense_layer.py
@@ -185,6 +185,130 @@ def test_create_translation_populates_sense_fks(db_app):
     assert t.target_sense.word_id == yo.w_id
 
 
+# ---- Phase 6c: sense-grouped response on /api/translate ----
+
+
+def test_translate_response_includes_senses_field_with_default_metadata(db_app):
+    import alarino_backend.translation_service as translation_service
+
+    en = add_word(language=Language.ENGLISH, word_text="hello")
+    yo = add_word(language=Language.YORUBA, word_text="bawo")
+    db.session.flush()
+    create_translation(en, yo)
+    db.session.commit()
+
+    response, status = translation_service.translate(
+        db, "hello", Language.ENGLISH, Language.YORUBA, "pytest-agent"
+    )
+    assert status == 200
+    senses = response["data"]["senses"]
+    assert len(senses) == 1
+    group = senses[0]
+    # Default sense from create_translation has no curated metadata.
+    assert group["label"] is None
+    assert group["definition"] is None
+    assert group["register"] is None
+    assert group["domain"] is None
+    assert group["translations"] == [
+        {"word": "bawo", "note": None, "provenance": None, "examples": []}
+    ]
+
+
+def test_translate_response_groups_polysemous_word_into_multiple_senses(db_app):
+    """The product story for the sense layer: a polysemous word like "bank"
+    surfaces multiple sense groups, each with its own translations."""
+    import alarino_backend.translation_service as translation_service
+    from alarino_backend.db_models import Sense, Translation
+
+    bank = add_word(language=Language.ENGLISH, word_text="bank")
+    ile_ifo = add_word(language=Language.YORUBA, word_text="ifowopamo")  # financial
+    bebe = add_word(language=Language.YORUBA, word_text="bebe")  # river
+    db.session.flush()
+
+    financial = Sense(
+        word_id=bank.w_id,
+        sense_label="financial",
+        definition="A financial institution",
+        part_of_speech="n",
+    )
+    river = Sense(
+        word_id=bank.w_id,
+        sense_label="river",
+        definition="Land alongside a river",
+        part_of_speech="n",
+    )
+    ife_sense = Sense(word_id=ile_ifo.w_id, sense_label="financial", part_of_speech="n")
+    bebe_sense = Sense(word_id=bebe.w_id, sense_label="river", part_of_speech="n")
+    db.session.add_all([financial, river, ife_sense, bebe_sense])
+    db.session.flush()
+
+    db.session.add_all([
+        Translation(
+            source_word_id=bank.w_id,
+            target_word_id=ile_ifo.w_id,
+            source_sense_id=financial.sense_id,
+            target_sense_id=ife_sense.sense_id,
+            note="financial sense",
+            provenance="curated",
+        ),
+        Translation(
+            source_word_id=bank.w_id,
+            target_word_id=bebe.w_id,
+            source_sense_id=river.sense_id,
+            target_sense_id=bebe_sense.sense_id,
+            note="river sense",
+            provenance="curated",
+        ),
+    ])
+    db.session.commit()
+
+    response, status = translation_service.translate(
+        db, "bank", Language.ENGLISH, Language.YORUBA, "pytest-agent"
+    )
+    assert status == 200
+    # Flat list still surfaces both translations (backward compat).
+    assert sorted(response["data"]["translation"]) == sorted(["ifowopamo", "bebe"])
+    # The new senses field separates them.
+    senses = response["data"]["senses"]
+    assert len(senses) == 2
+    by_label = {s["label"]: s for s in senses}
+    assert "financial" in by_label and "river" in by_label
+    assert by_label["financial"]["definition"] == "A financial institution"
+    assert by_label["financial"]["translations"][0]["word"] == "ifowopamo"
+    assert by_label["financial"]["translations"][0]["note"] == "financial sense"
+    assert by_label["river"]["translations"][0]["word"] == "bebe"
+    assert by_label["river"]["translations"][0]["note"] == "river sense"
+
+
+def test_translate_response_carries_examples_attached_to_sense_pair(db_app):
+    import alarino_backend.translation_service as translation_service
+    from alarino_backend.db_models import Example, Translation
+
+    en = add_word(language=Language.ENGLISH, word_text="hello")
+    yo = add_word(language=Language.YORUBA, word_text="bawo")
+    db.session.flush()
+    create_translation(en, yo)
+    db.session.commit()
+    t = Translation.query.one()
+    db.session.add(
+        Example(
+            translation_id=t.t_id,
+            source_sense_id=t.source_sense_id,
+            target_sense_id=t.target_sense_id,
+            example_source="Hello there",
+            example_target="Bawo nibe",
+        )
+    )
+    db.session.commit()
+
+    response, status = translation_service.translate(
+        db, "hello", Language.ENGLISH, Language.YORUBA, "pytest-agent"
+    )
+    assert status == 200
+    examples = response["data"]["senses"][0]["translations"][0]["examples"]
+    assert examples == [{"source": "Hello there", "target": "Bawo nibe"}]
+
+
 def test_create_translation_reuses_existing_default_sense(db_app):
     en = add_word(language=Language.ENGLISH, word_text="hello")
     yo = add_word(language=Language.YORUBA, word_text="bawo")

--- a/alarino_backend/tests/test_sense_layer.py
+++ b/alarino_backend/tests/test_sense_layer.py
@@ -63,18 +63,14 @@ def test_translation_has_new_metadata_columns():
         assert new_col in columns, f"Translation must have new column {new_col!r}"
 
 
-def test_word_part_of_speech_still_present():
-    # Phase 6a keeps Word.part_of_speech for read-path compatibility.
-    # Phase 6d drops it after the cutover.
-    assert "part_of_speech" in {c.name for c in Word.__table__.columns}
+def test_word_part_of_speech_dropped_in_phase_6d():
+    # Phase 6d removed Word.part_of_speech. POS lives only on Sense now.
+    assert "part_of_speech" not in {c.name for c in Word.__table__.columns}
 
 
-def test_translation_sense_fk_columns_are_nullable_in_phase_6a():
-    # Phase 6a leaves source_sense_id and target_sense_id nullable so the
-    # backfill can run incrementally and so existing write paths that
-    # don't yet set them keep working. Phase 6d makes them NOT NULL.
-    assert Translation.__table__.c.source_sense_id.nullable is True
-    assert Translation.__table__.c.target_sense_id.nullable is True
+def test_translation_sense_fk_columns_are_not_null_in_phase_6d():
+    assert Translation.__table__.c.source_sense_id.nullable is False
+    assert Translation.__table__.c.target_sense_id.nullable is False
 
 
 # ---- Sense behavior under db.create_all (model-only, no migration backfill) ----
@@ -156,10 +152,10 @@ def test_example_has_sense_fk_columns():
     assert "target_sense_id" in columns
 
 
-def test_example_translation_id_still_present_in_phase_6b():
-    # Phase 6b keeps translation_id on Example so the legacy relationship
-    # and read paths keep working through 6c. Phase 6d drops it.
-    assert "translation_id" in {c.name for c in Example.__table__.columns}
+def test_example_translation_id_dropped_in_phase_6d():
+    # Phase 6d dropped Example.translation_id. The link to a translation
+    # is now indirect via the (source_sense_id, target_sense_id) pair.
+    assert "translation_id" not in {c.name for c in Example.__table__.columns}
 
 
 def test_example_sense_columns_nullable_in_phase_6b():
@@ -292,7 +288,6 @@ def test_translate_response_carries_examples_attached_to_sense_pair(db_app):
     t = Translation.query.one()
     db.session.add(
         Example(
-            translation_id=t.t_id,
             source_sense_id=t.source_sense_id,
             target_sense_id=t.target_sense_id,
             example_source="Hello there",

--- a/alarino_backend/tests/test_sense_layer.py
+++ b/alarino_backend/tests/test_sense_layer.py
@@ -77,7 +77,7 @@ def test_translation_sense_fk_columns_are_not_null_in_phase_6d():
 
 
 def test_sense_can_be_created_for_a_word(db_app):
-    word = Word(language="yo", word="ile")
+    word = Word(language="yo", text="ile")
     db.session.add(word)
     db.session.flush()
     sense = Sense(
@@ -99,7 +99,7 @@ def test_sense_can_be_created_for_a_word(db_app):
 
 def test_word_to_senses_relationship(db_app):
     # Word.senses backref returns a list, supporting polysemy from Phase 6b on.
-    word = Word(language="en", word="bank")
+    word = Word(language="en", text="bank")
     db.session.add(word)
     db.session.flush()
     db.session.add_all([
@@ -108,13 +108,13 @@ def test_word_to_senses_relationship(db_app):
     ])
     db.session.commit()
 
-    refreshed = Word.query.filter_by(word="bank").one()
+    refreshed = Word.query.filter_by(text="bank").one()
     assert {s.sense_label for s in refreshed.senses} == {"financial", "river"}
 
 
 def test_translation_can_carry_metadata(db_app):
-    en = Word(language="en", word="hello")
-    yo = Word(language="yo", word="bawo")
+    en = Word(language="en", text="hello")
+    yo = Word(language="yo", text="bawo")
     db.session.add_all([en, yo])
     db.session.flush()
     en_sense = Sense(word_id=en.w_id, sense_label="greeting")
@@ -329,7 +329,7 @@ def test_sense_word_id_fk_uses_db_level_cascade(db_app):
     # SQLAlchemy's ORM cascade, which has its own pre-delete NULL-out
     # behavior that would interfere). On SQLite, foreign keys must be
     # enabled per-connection.
-    word = Word(language="yo", word="ile")
+    word = Word(language="yo", text="ile")
     db.session.add(word)
     db.session.flush()
     db.session.add(Sense(word_id=word.w_id, sense_label="building"))

--- a/alarino_backend/tests/test_translation_service.py
+++ b/alarino_backend/tests/test_translation_service.py
@@ -1,6 +1,11 @@
 from types import SimpleNamespace
 
+import pytest
+
+import alarino_backend.app as app_module
 import alarino_backend.translation_service as translation_service
+from alarino_backend import db
+from alarino_backend.db_models import MissingTranslation, Word
 from alarino_backend.languages import Language
 
 
@@ -264,3 +269,78 @@ def test_translate_llm_returns_500_when_service_raises(monkeypatch):
 
     assert status == 500
     assert response["message"] == "An error occurred during translation."
+
+
+def test_word_created_at_default_is_callable():
+    # Regression: default was previously datetime.now() (called once at import),
+    # so every Word row received the same timestamp. Must be a callable.
+    default = Word.__table__.c.created_at.default
+    assert default is not None
+    assert callable(default.arg), (
+        f"Word.created_at default must be a callable, got {default.arg!r}"
+    )
+
+
+@pytest.fixture
+def db_app():
+    app = app_module.create_app()
+    app.config["TESTING"] = True
+    with app.app_context():
+        db.create_all()
+        try:
+            yield app
+        finally:
+            db.session.remove()
+            db.drop_all()
+
+
+def test_log_missing_translation_inserts_on_first_call(db_app):
+    translation_service.log_missing_translation(
+        db, "ile", Language.YORUBA, Language.ENGLISH, "203.0.113.10", "pytest-agent"
+    )
+
+    rows = MissingTranslation.query.all()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.text == "ile"
+    assert row.source_language == Language.YORUBA.value
+    assert row.target_language == Language.ENGLISH.value
+    assert row.user_ip == "203.0.113.10"
+    assert row.user_agent == "pytest-agent"
+    assert row.hit_count == 1
+
+
+def test_log_missing_translation_increments_hit_count_on_conflict(db_app):
+    translation_service.log_missing_translation(
+        db, "ile", Language.YORUBA, Language.ENGLISH, "203.0.113.10", "first-agent"
+    )
+    translation_service.log_missing_translation(
+        db, "ile", Language.YORUBA, Language.ENGLISH, "198.51.100.20", "second-agent"
+    )
+    translation_service.log_missing_translation(
+        db, "ile", Language.YORUBA, Language.ENGLISH, "198.51.100.21", "third-agent"
+    )
+
+    rows = MissingTranslation.query.all()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.hit_count == 3
+    # First reporter's identity is preserved; subsequent IPs/agents do not overwrite.
+    assert row.user_ip == "203.0.113.10"
+    assert row.user_agent == "first-agent"
+
+
+def test_log_missing_translation_distinct_tuples_create_separate_rows(db_app):
+    translation_service.log_missing_translation(
+        db, "ile", Language.YORUBA, Language.ENGLISH, "203.0.113.10", "pytest-agent"
+    )
+    translation_service.log_missing_translation(
+        db, "house", Language.ENGLISH, Language.YORUBA, "203.0.113.10", "pytest-agent"
+    )
+    translation_service.log_missing_translation(
+        db, "ile", Language.YORUBA, Language.ENGLISH, "203.0.113.10", "pytest-agent"
+    )
+
+    rows = MissingTranslation.query.order_by(MissingTranslation.text).all()
+    assert len(rows) == 2
+    assert {row.text: row.hit_count for row in rows} == {"house": 1, "ile": 2}

--- a/alarino_backend/tests/test_translation_service.py
+++ b/alarino_backend/tests/test_translation_service.py
@@ -89,80 +89,37 @@ def test_translate_logs_missing_word_when_source_word_does_not_exist(monkeypatch
     ]
 
 
-def test_translate_logs_missing_when_translation_is_unavailable(monkeypatch):
-    source_word = SimpleNamespace(w_id=7, word="hello")
-    word_query = QueryStub(first_result=source_word)
-    translation_query = QueryStub(all_result=[])
-    missing_logs = []
-    fake_db = SimpleNamespace()
-
-    monkeypatch.setattr(
-        translation_service,
-        "Word",
-        SimpleNamespace(query=word_query, language=object(), w_id=object()),
-    )
-    monkeypatch.setattr(
-        translation_service,
-        "Translation",
-        SimpleNamespace(query=translation_query, target_word_id=object()),
-    )
-    monkeypatch.setattr(
-        translation_service,
-        "log_missing_translation",
-        lambda *args: missing_logs.append(args),
-    )
+def test_translate_logs_missing_when_translation_is_unavailable(db_app):
+    # Word exists but no Translation row in either direction.
+    db.session.add(Word(language="en", word="hello"))
+    db.session.commit()
 
     response, status = translation_service.translate(
-        db=fake_db,
-        text="hello",
-        source=Language.ENGLISH,
-        target=Language.YORUBA,
-        user_agent="pytest-agent",
+        db, "hello", Language.ENGLISH, Language.YORUBA, "pytest-agent"
     )
 
     assert status == 404
     assert response["message"] == "Word found but translation not available."
-    assert translation_query.filter_by_calls == [{"source_word_id": 7}]
-    assert missing_logs == [
-        (
-            fake_db,
-            "hello",
-            Language.ENGLISH,
-            Language.YORUBA,
-            "pytest-agent",
-        )
-    ]
+
+    rows = MissingTranslation.query.all()
+    assert len(rows) == 1
+    assert rows[0].text == "hello"
+    assert rows[0].source_language == Language.ENGLISH.value
+    assert rows[0].target_language == Language.YORUBA.value
 
 
-def test_translate_returns_successful_translation_payload(monkeypatch):
-    source_word = SimpleNamespace(w_id=7, word="hello")
-    translated_word = SimpleNamespace(word="bawo")
-    translation = SimpleNamespace(target_word=translated_word)
-    word_query = QueryStub(first_result=source_word)
-    translation_query = QueryStub(all_result=[translation])
+def test_translate_returns_successful_translation_payload(db_app):
+    from alarino_backend.db_models import Translation
 
-    monkeypatch.setattr(
-        translation_service,
-        "Word",
-        SimpleNamespace(query=word_query, language=object(), w_id=object()),
-    )
-    monkeypatch.setattr(
-        translation_service,
-        "Translation",
-        SimpleNamespace(query=translation_query, target_word_id=object()),
-    )
-    monkeypatch.setattr(
-        translation_service,
-        "log_missing_translation",
-        lambda *args: (_ for _ in ()).throw(AssertionError("should not log missing translation")),
-    )
+    hello = Word(language="en", word="hello")
+    bawo = Word(language="yo", word="bawo")
+    db.session.add_all([hello, bawo])
+    db.session.flush()
+    db.session.add(Translation(source_word_id=hello.w_id, target_word_id=bawo.w_id))
+    db.session.commit()
 
     response, status = translation_service.translate(
-        db=SimpleNamespace(),
-        text=" Hello ",
-        source=Language.ENGLISH,
-        target=Language.YORUBA,
-        user_agent="pytest-agent",
+        db, " Hello ", Language.ENGLISH, Language.YORUBA, "pytest-agent"
     )
 
     assert status == 200
@@ -336,3 +293,104 @@ def test_log_missing_translation_distinct_tuples_create_separate_rows(db_app):
     rows = MissingTranslation.query.order_by(MissingTranslation.text).all()
     assert len(rows) == 2
     assert {row.text: row.hit_count for row in rows} == {"house": 1, "ile": 2}
+
+
+# ---- Phase 4: bidirectional lookup ----
+# A Translation row is stored as a directed edge (curator added it as
+# source→target). Lookups in *either* direction must succeed if either
+# direction is curated.
+
+
+def _seed_one_directional_pair(en_text: str, yo_text: str):
+    """Seed a single curated en→yo Translation. Returns (en_word, yo_word)."""
+    from alarino_backend.db_models import Translation
+
+    en = Word(language="en", word=en_text)
+    yo = Word(language="yo", word=yo_text)
+    db.session.add_all([en, yo])
+    db.session.flush()
+    db.session.add(Translation(source_word_id=en.w_id, target_word_id=yo.w_id))
+    db.session.commit()
+    return en, yo
+
+
+def test_translate_finds_curated_forward_direction(db_app):
+    _seed_one_directional_pair("hello", "bawo")
+
+    response, status = translation_service.translate(
+        db, "hello", Language.ENGLISH, Language.YORUBA, "pytest-agent"
+    )
+    assert status == 200
+    assert response["data"]["translation"] == ["bawo"]
+
+
+def test_translate_finds_reverse_direction_via_bidirectional_lookup(db_app):
+    # Only the en→yo direction was curated, but yo→en lookup should succeed.
+    _seed_one_directional_pair("hello", "bawo")
+
+    response, status = translation_service.translate(
+        db, "bawo", Language.YORUBA, Language.ENGLISH, "pytest-agent"
+    )
+    assert status == 200
+    assert response["data"]["translation"] == ["hello"]
+
+
+def test_translate_dedupes_when_both_directions_curated(db_app):
+    # Curating both directions must not return duplicate results — the bidirectional
+    # lookup deduplicates by w_id of the opposite-side word.
+    from alarino_backend.db_models import Translation
+
+    en, yo = _seed_one_directional_pair("hello", "bawo")
+    db.session.add(Translation(source_word_id=yo.w_id, target_word_id=en.w_id))
+    db.session.commit()
+
+    forward, status_f = translation_service.translate(
+        db, "hello", Language.ENGLISH, Language.YORUBA, "pytest-agent"
+    )
+    reverse, status_r = translation_service.translate(
+        db, "bawo", Language.YORUBA, Language.ENGLISH, "pytest-agent"
+    )
+    assert status_f == 200 and forward["data"]["translation"] == ["bawo"]
+    assert status_r == 200 and reverse["data"]["translation"] == ["hello"]
+
+
+def test_translate_returns_all_target_language_translations_in_either_direction(db_app):
+    # Multiple Yoruba synonyms for "child", each curated en→yo. yo→en lookup of
+    # any one must return ["child"]; en→yo lookup of "child" must return all
+    # Yoruba synonyms.
+    from alarino_backend.db_models import Translation
+
+    child = Word(language="en", word="child")
+    omo = Word(language="yo", word="ọmọ")
+    egbon = Word(language="yo", word="ẹgbọn")
+    db.session.add_all([child, omo, egbon])
+    db.session.flush()
+    db.session.add_all([
+        Translation(source_word_id=child.w_id, target_word_id=omo.w_id),
+        Translation(source_word_id=child.w_id, target_word_id=egbon.w_id),
+    ])
+    db.session.commit()
+
+    response, status = translation_service.translate(
+        db, "child", Language.ENGLISH, Language.YORUBA, "pytest-agent"
+    )
+    assert status == 200
+    assert sorted(response["data"]["translation"]) == sorted(["ọmọ", "ẹgbọn"])
+
+    response_yo, status_yo = translation_service.translate(
+        db, "ọmọ", Language.YORUBA, Language.ENGLISH, "pytest-agent"
+    )
+    assert status_yo == 200
+    assert response_yo["data"]["translation"] == ["child"]
+
+
+def test_translate_returns_404_when_no_curated_translation_in_either_direction(db_app):
+    # Word exists in source language but no Translation row at all.
+    db.session.add(Word(language="en", word="lonely"))
+    db.session.commit()
+
+    response, status = translation_service.translate(
+        db, "lonely", Language.ENGLISH, Language.YORUBA, "pytest-agent"
+    )
+    assert status == 404
+    assert response["message"] == "Word found but translation not available."

--- a/alarino_backend/tests/test_translation_service.py
+++ b/alarino_backend/tests/test_translation_service.py
@@ -77,7 +77,7 @@ def test_translate_logs_missing_word_when_source_word_does_not_exist(monkeypatch
 
     assert status == 404
     assert response["message"] == "Word not found."
-    assert word_query.filter_by_calls == [{"language": Language.ENGLISH, "word": "hello"}]
+    assert word_query.filter_by_calls == [{"language": Language.ENGLISH, "text": "hello"}]
     assert missing_logs == [
         (
             fake_db,
@@ -91,7 +91,7 @@ def test_translate_logs_missing_word_when_source_word_does_not_exist(monkeypatch
 
 def test_translate_logs_missing_when_translation_is_unavailable(db_app):
     # Word exists but no Translation row in either direction.
-    db.session.add(Word(language="en", word="hello"))
+    db.session.add(Word(language="en", text="hello"))
     db.session.commit()
 
     response, status = translation_service.translate(
@@ -111,8 +111,8 @@ def test_translate_logs_missing_when_translation_is_unavailable(db_app):
 def test_translate_returns_successful_translation_payload(db_app):
     from alarino_backend.data.seed_data_utils import create_translation
 
-    hello = Word(language="en", word="hello")
-    bawo = Word(language="yo", word="bawo")
+    hello = Word(language="en", text="hello")
+    bawo = Word(language="yo", text="bawo")
     db.session.add_all([hello, bawo])
     db.session.flush()
     create_translation(hello, bawo)
@@ -319,8 +319,8 @@ def _seed_one_directional_pair(en_text: str, yo_text: str):
     """Seed a single curated en→yo Translation. Returns (en_word, yo_word)."""
     from alarino_backend.data.seed_data_utils import create_translation
 
-    en = Word(language="en", word=en_text)
-    yo = Word(language="yo", word=yo_text)
+    en = Word(language="en", text=en_text)
+    yo = Word(language="yo", text=yo_text)
     db.session.add_all([en, yo])
     db.session.flush()
     create_translation(en, yo)
@@ -374,9 +374,9 @@ def test_translate_returns_all_target_language_translations_in_either_direction(
     # Yoruba synonyms.
     from alarino_backend.data.seed_data_utils import create_translation
 
-    child = Word(language="en", word="child")
-    omo = Word(language="yo", word="ọmọ")
-    egbon = Word(language="yo", word="ẹgbọn")
+    child = Word(language="en", text="child")
+    omo = Word(language="yo", text="ọmọ")
+    egbon = Word(language="yo", text="ẹgbọn")
     db.session.add_all([child, omo, egbon])
     db.session.flush()
     create_translation(child, omo)
@@ -398,7 +398,7 @@ def test_translate_returns_all_target_language_translations_in_either_direction(
 
 def test_translate_returns_404_when_no_curated_translation_in_either_direction(db_app):
     # Word exists in source language but no Translation row at all.
-    db.session.add(Word(language="en", word="lonely"))
+    db.session.add(Word(language="en", text="lonely"))
     db.session.commit()
 
     response, status = translation_service.translate(

--- a/alarino_backend/tests/test_translation_service.py
+++ b/alarino_backend/tests/test_translation_service.py
@@ -123,16 +123,32 @@ def test_translate_returns_successful_translation_payload(db_app):
     )
 
     assert status == 200
-    assert response == {
-        "success": True,
-        "status": 200,
-        "message": "Translation successful.",
-        "data": {
-            "translation": ["bawo"],
-            "source_word": "hello",
-            "to_language": Language.YORUBA.value,
-        },
-    }
+    assert response["success"] is True
+    assert response["status"] == 200
+    assert response["message"] == "Translation successful."
+    assert response["data"]["translation"] == ["bawo"]
+    assert response["data"]["source_word"] == "hello"
+    assert response["data"]["to_language"] == Language.YORUBA.value
+    # Phase 6c: senses field is additive. The seeded Translation didn't go
+    # through create_translation so its sense FKs are NULL — expect a single
+    # default-bucket group with empty metadata.
+    assert response["data"]["senses"] == [
+        {
+            "label": None,
+            "definition": None,
+            "register": None,
+            "domain": None,
+            "part_of_speech": None,
+            "translations": [
+                {
+                    "word": "bawo",
+                    "note": None,
+                    "provenance": None,
+                    "examples": [],
+                }
+            ],
+        }
+    ]
 
 
 def test_translate_llm_returns_400_for_empty_text():
@@ -176,16 +192,14 @@ def test_translate_llm_returns_successful_translation_payload(monkeypatch):
     )
 
     assert status == 200
-    assert response == {
-        "success": True,
-        "status": 200,
-        "message": "Translation successful.",
-        "data": {
-            "translation": ["bawo"],
-            "source_word": "hello",
-            "to_language": Language.YORUBA.value,
-        },
-    }
+    # translate_llm doesn't query the DB; senses field defaults to empty.
+    assert response["success"] is True
+    assert response["status"] == 200
+    assert response["message"] == "Translation successful."
+    assert response["data"]["translation"] == ["bawo"]
+    assert response["data"]["source_word"] == "hello"
+    assert response["data"]["to_language"] == Language.YORUBA.value
+    assert response["data"]["senses"] == []
 
 
 def test_translate_llm_returns_404_when_no_translation_is_found(monkeypatch):

--- a/alarino_backend/tests/test_translation_service.py
+++ b/alarino_backend/tests/test_translation_service.py
@@ -44,7 +44,6 @@ def test_translate_returns_400_for_empty_text():
         text="   ",
         source=Language.ENGLISH,
         target=Language.YORUBA,
-        addr="203.0.113.10",
         user_agent="pytest-agent",
     )
 
@@ -73,7 +72,6 @@ def test_translate_logs_missing_word_when_source_word_does_not_exist(monkeypatch
         text=" Hello ",
         source=Language.ENGLISH,
         target=Language.YORUBA,
-        addr="203.0.113.10",
         user_agent="pytest-agent",
     )
 
@@ -86,7 +84,6 @@ def test_translate_logs_missing_word_when_source_word_does_not_exist(monkeypatch
             "hello",
             Language.ENGLISH,
             Language.YORUBA,
-            "203.0.113.10",
             "pytest-agent",
         )
     ]
@@ -120,7 +117,6 @@ def test_translate_logs_missing_when_translation_is_unavailable(monkeypatch):
         text="hello",
         source=Language.ENGLISH,
         target=Language.YORUBA,
-        addr="203.0.113.10",
         user_agent="pytest-agent",
     )
 
@@ -133,7 +129,6 @@ def test_translate_logs_missing_when_translation_is_unavailable(monkeypatch):
             "hello",
             Language.ENGLISH,
             Language.YORUBA,
-            "203.0.113.10",
             "pytest-agent",
         )
     ]
@@ -167,7 +162,6 @@ def test_translate_returns_successful_translation_payload(monkeypatch):
         text=" Hello ",
         source=Language.ENGLISH,
         target=Language.YORUBA,
-        addr="203.0.113.10",
         user_agent="pytest-agent",
     )
 
@@ -296,7 +290,7 @@ def db_app():
 
 def test_log_missing_translation_inserts_on_first_call(db_app):
     translation_service.log_missing_translation(
-        db, "ile", Language.YORUBA, Language.ENGLISH, "203.0.113.10", "pytest-agent"
+        db, "ile", Language.YORUBA, Language.ENGLISH, "pytest-agent"
     )
 
     rows = MissingTranslation.query.all()
@@ -305,40 +299,38 @@ def test_log_missing_translation_inserts_on_first_call(db_app):
     assert row.text == "ile"
     assert row.source_language == Language.YORUBA.value
     assert row.target_language == Language.ENGLISH.value
-    assert row.user_ip == "203.0.113.10"
     assert row.user_agent == "pytest-agent"
     assert row.hit_count == 1
 
 
 def test_log_missing_translation_increments_hit_count_on_conflict(db_app):
     translation_service.log_missing_translation(
-        db, "ile", Language.YORUBA, Language.ENGLISH, "203.0.113.10", "first-agent"
+        db, "ile", Language.YORUBA, Language.ENGLISH, "first-agent"
     )
     translation_service.log_missing_translation(
-        db, "ile", Language.YORUBA, Language.ENGLISH, "198.51.100.20", "second-agent"
+        db, "ile", Language.YORUBA, Language.ENGLISH, "second-agent"
     )
     translation_service.log_missing_translation(
-        db, "ile", Language.YORUBA, Language.ENGLISH, "198.51.100.21", "third-agent"
+        db, "ile", Language.YORUBA, Language.ENGLISH, "third-agent"
     )
 
     rows = MissingTranslation.query.all()
     assert len(rows) == 1
     row = rows[0]
     assert row.hit_count == 3
-    # First reporter's identity is preserved; subsequent IPs/agents do not overwrite.
-    assert row.user_ip == "203.0.113.10"
+    # First reporter's user_agent is preserved; subsequent values do not overwrite.
     assert row.user_agent == "first-agent"
 
 
 def test_log_missing_translation_distinct_tuples_create_separate_rows(db_app):
     translation_service.log_missing_translation(
-        db, "ile", Language.YORUBA, Language.ENGLISH, "203.0.113.10", "pytest-agent"
+        db, "ile", Language.YORUBA, Language.ENGLISH, "pytest-agent"
     )
     translation_service.log_missing_translation(
-        db, "house", Language.ENGLISH, Language.YORUBA, "203.0.113.10", "pytest-agent"
+        db, "house", Language.ENGLISH, Language.YORUBA, "pytest-agent"
     )
     translation_service.log_missing_translation(
-        db, "ile", Language.YORUBA, Language.ENGLISH, "203.0.113.10", "pytest-agent"
+        db, "ile", Language.YORUBA, Language.ENGLISH, "pytest-agent"
     )
 
     rows = MissingTranslation.query.order_by(MissingTranslation.text).all()

--- a/alarino_backend/tests/test_translation_service.py
+++ b/alarino_backend/tests/test_translation_service.py
@@ -109,13 +109,13 @@ def test_translate_logs_missing_when_translation_is_unavailable(db_app):
 
 
 def test_translate_returns_successful_translation_payload(db_app):
-    from alarino_backend.db_models import Translation
+    from alarino_backend.data.seed_data_utils import create_translation
 
     hello = Word(language="en", word="hello")
     bawo = Word(language="yo", word="bawo")
     db.session.add_all([hello, bawo])
     db.session.flush()
-    db.session.add(Translation(source_word_id=hello.w_id, target_word_id=bawo.w_id))
+    create_translation(hello, bawo)
     db.session.commit()
 
     response, status = translation_service.translate(
@@ -317,13 +317,13 @@ def test_log_missing_translation_distinct_tuples_create_separate_rows(db_app):
 
 def _seed_one_directional_pair(en_text: str, yo_text: str):
     """Seed a single curated en→yo Translation. Returns (en_word, yo_word)."""
-    from alarino_backend.db_models import Translation
+    from alarino_backend.data.seed_data_utils import create_translation
 
     en = Word(language="en", word=en_text)
     yo = Word(language="yo", word=yo_text)
     db.session.add_all([en, yo])
     db.session.flush()
-    db.session.add(Translation(source_word_id=en.w_id, target_word_id=yo.w_id))
+    create_translation(en, yo)
     db.session.commit()
     return en, yo
 
@@ -352,10 +352,10 @@ def test_translate_finds_reverse_direction_via_bidirectional_lookup(db_app):
 def test_translate_dedupes_when_both_directions_curated(db_app):
     # Curating both directions must not return duplicate results — the bidirectional
     # lookup deduplicates by w_id of the opposite-side word.
-    from alarino_backend.db_models import Translation
+    from alarino_backend.data.seed_data_utils import create_translation
 
     en, yo = _seed_one_directional_pair("hello", "bawo")
-    db.session.add(Translation(source_word_id=yo.w_id, target_word_id=en.w_id))
+    create_translation(yo, en)
     db.session.commit()
 
     forward, status_f = translation_service.translate(
@@ -372,17 +372,15 @@ def test_translate_returns_all_target_language_translations_in_either_direction(
     # Multiple Yoruba synonyms for "child", each curated en→yo. yo→en lookup of
     # any one must return ["child"]; en→yo lookup of "child" must return all
     # Yoruba synonyms.
-    from alarino_backend.db_models import Translation
+    from alarino_backend.data.seed_data_utils import create_translation
 
     child = Word(language="en", word="child")
     omo = Word(language="yo", word="ọmọ")
     egbon = Word(language="yo", word="ẹgbọn")
     db.session.add_all([child, omo, egbon])
     db.session.flush()
-    db.session.add_all([
-        Translation(source_word_id=child.w_id, target_word_id=omo.w_id),
-        Translation(source_word_id=child.w_id, target_word_id=egbon.w_id),
-    ])
+    create_translation(child, omo)
+    create_translation(child, egbon)
     db.session.commit()
 
     response, status = translation_service.translate(

--- a/docs/plans/schema_evolution_plan.md
+++ b/docs/plans/schema_evolution_plan.md
@@ -1,0 +1,292 @@
+# Schema Evolution Plan
+
+## Objective
+
+Evolve the existing alarino database in place — using Alembic migrations on the live PostgreSQL database — to fix a small number of correctness bugs, retire schema hygiene debt, and restructure the core lexical model so it can represent a real bilingual dictionary (senses, definitions, sense-scoped examples, connected proverbs) rather than a flat word-pair store.
+
+The work is sequenced so each phase is independently shippable. Most phases are individually reversible; the few that aren't (data dedup, dropping columns) are explicitly called out. Higher-value but higher-risk structural changes come after the safe hygiene work has built confidence in the migration pipeline.
+
+## Current Problems
+
+Bugs:
+
+- `Word.created_at` uses `default=datetime.now()` (called once at import) instead of `default=datetime.now` (callable). Every new `Word` row gets the timestamp the process started.
+- `MissingTranslation.hit_count` is incremented via read-modify-write in `translation_service.log_missing_translation`, which loses concurrent increments.
+
+Hygiene:
+
+- Several declared indexes duplicate the btree that backs a unique constraint (`idx_words_language_word`, `idx_missing_text_source_target`, prefix of `idx_proverbs_yoruba_text` and `idx_translations_source_word_id`).
+- `idx_words_language` indexes a 2-value column and is never used by the planner.
+- `created_at` is nullable on every table and has no `server_default`, so direct SQL inserts produce NULLs.
+- `MissingTranslation.hit_count` is nullable.
+- `Example` has no unique constraint; the same example can be inserted N times against the same translation.
+
+Structural:
+
+- There is no sense layer between `Word` and `Translation`. `part_of_speech` lives on `Word` even though POS depends on sense, and `UNIQUE (language, word)` then prevents the same word from carrying multiple POS values. Polysemous entries ("bank" → financial vs riverbank) are stored as undifferentiated translation pairs.
+- `Translation` carries no metadata (definition, gloss, register, domain, source, confidence). Examples attach to `Translation`, not to a sense, so they cannot be disambiguated.
+- `Translation` is stored as a directed edge but lookup queries only one direction (`translation_service.translate` filters on `source_word_id` only). Reverse lookups silently miss unless an inverse row was also inserted, and nothing in the schema enforces the inverse.
+- `DailyWord` stores two independent FKs (`word_id`, `en_word_id`) with no constraint that they actually form a translation pair.
+- `Proverb` has no relationship to `Word`. The seed loader extracts individual words and discards the link.
+- `language` is a free-form `String(3)` with no constraint; `'en'`, `'eng'`, `'EN'` could all coexist.
+- `MissingTranslation` mixes telemetry (`user_ip`, `user_agent`, `hit_count`) into the lexical schema. After the Phase 0 upsert change, only one row exists per missed (text, source, target) tuple, so `user_ip` cannot represent meaningful "who asked" telemetry — it can only represent "the first asker" or "an arbitrary later asker."
+- `Word.word` has a TODO to be renamed to `text`.
+
+## Non-Goals
+
+- No move to fully multilingual storage in this plan. The remaining bilingual hardcoding (`Proverb.yoruba_text`/`english_text`, `is_valid_english_word` / `is_valid_yoruba_word` validators) is left intact. `DailyWord` is rewritten in Phase 5 because the change is independently valuable as a normalization fix, not as multilingual prep. If a third language becomes a real roadmap item, a follow-up plan can replace `Proverb`'s text columns with a `proverb_translations` join table and broaden the validator registry.
+- No new product features (audio/IPA, tags, user accounts, edit history, attribution UI). The schema is left structured so these can be added without further restructuring, but they are out of scope here.
+- No rewrite of the LLM translation path.
+- No data backfill from external sources.
+- No introduction of per-request telemetry. The plan removes `user_ip` rather than reshaping it; if per-event analytics is wanted later, that's a separate `missing_translation_events` table done as its own follow-up.
+
+## Migration Principles
+
+- Every phase ships as one or more Alembic revisions. No phase depends on uncommitted work in the next.
+- Destructive column changes follow expand/contract: add the new shape, dual-write, cut reads over, drop the old. A rollback during cutover means flipping reads back, not restoring data.
+- Backfills run in the same revision as the column add when the table is small (every table here qualifies). For anything that grows past ~100k rows during the plan, the backfill moves to a separate batched script.
+- Alembic revisions stay deterministic. Anything that requires a runtime secret, reads from external services, or could fail nondeterministically lives in a controlled backfill script that runs *outside* the Alembic upgrade, with an explicit preflight check that the script ran before the next revision is applied.
+- Data-destructive operations (deletes, dropping columns) are always called out explicitly. Before any destructive step, the migration logs the rows being removed to a sidecar table (or to stdout in development) so the deletion can be audited.
+- Before any phase that drops or renames a column, ensure no code references the old name. CI runs the test suite against a fresh migrate-from-empty *and* a migrate-from-previous-revision.
+- Each phase is reviewed and merged independently. No "big bang" PR.
+
+## Phase 0 — Bug Fixes (no migrations)
+
+Code-only changes. No schema impact.
+
+1. `db_models.Word.created_at`: change `default=datetime.now()` to `default=datetime.now`.
+2. `translation_service.log_missing_translation`: replace the read-modify-write with a single atomic upsert against the `unique_missing_translation` constraint:
+   ```
+   INSERT INTO missing_translations (...) VALUES (...)
+   ON CONFLICT (text, source_language, target_language)
+   DO UPDATE SET hit_count = missing_translations.hit_count + 1
+   ```
+   Use SQLAlchemy's `postgresql.insert(...).on_conflict_do_update(...)`.
+
+Risk: minimal. Tests cover both paths.
+
+## Phase 1 — Index and Constraint Hygiene
+
+One Alembic revision. Index drops and column-tightening are reversible. The `Example` deduplication step is **not reversible** and is called out explicitly.
+
+1. Drop redundant indexes (reversible):
+   - `idx_words_language_word` (covered by `unique_language_word`)
+   - `idx_words_language` (low-cardinality, never used)
+   - `idx_missing_text_source_target` (covered by `unique_missing_translation`)
+   - `idx_proverbs_yoruba_text` (covered by `unique_proverb_pair` prefix)
+   - `idx_translations_source_word_id` (covered by `unique_translation_pair` prefix)
+2. Tighten nullability and defaults (reversible):
+   - Backfill any NULL `created_at` rows with `now()`.
+   - Alter every `created_at` column to `NOT NULL` with `server_default=func.now()`.
+   - Alter `MissingTranslation.hit_count` to `NOT NULL DEFAULT 1`.
+3. **Data-destructive:** Deduplicate `Example` rows on `(translation_id, example_source, example_target)`, then add `UNIQUE (translation_id, example_source, example_target)`. Removed rows are logged to a `_phase1_removed_examples` sidecar table (raw JSON of each row) so the deletion can be reviewed. Downgrade only drops the constraint — it cannot reconstruct the deleted duplicates. The sidecar table is dropped in the next phase after manual review.
+
+Risk: low for steps 1–2. Step 3 is irreversible by design; review the sidecar dump in staging before running in prod.
+
+## Phase 2 — Language Constraint and Telemetry Cleanup
+
+One Alembic revision.
+
+1. Add `CHECK (language IN ('en', 'yo'))` on `Word.language`, `MissingTranslation.source_language`, `MissingTranslation.target_language`. (A `languages` reference table is overkill at two values; revisit if multilingual work happens.)
+2. Drop `MissingTranslation.user_ip` entirely. Rationale: after Phase 0's upsert change, only one row exists per missed tuple, so the column can hold at most one IP per missed word — that's neither meaningful "who asked" data nor useful aggregate telemetry. Dropping it is cleaner than hashing a value that has no analytic use, and it removes the privacy footprint with no loss of signal. If per-request telemetry is wanted later, add a separate events table (out of scope).
+
+Risk: low. The CHECK constraint will fail the migration loudly if any row carries a non-canonical language code — that surfaces existing data quality issues, which is the point. Dropping `user_ip` is data-destructive but the data has no remaining utility; rows are dumped to `_phase2_removed_user_ips` for audit.
+
+## Phase 3 — Connect Proverbs to Vocabulary
+
+One Alembic revision plus one backfill.
+
+1. Add `proverb_words(proverb_id, word_id, language, position)` join table with composite PK `(proverb_id, word_id, language, position)`. `position` preserves word order in the proverb.
+2. Backfill by re-running the existing word-extraction logic in `seed_data_utils.add_proverb` against every existing `Proverb` row, inserting `proverb_words` entries pointing at matching `Word` rows (creating any missing `Word` rows as it does today).
+3. Add a service method `get_proverbs_containing(word)` and update `add_proverb` so new inserts populate `proverb_words` going forward.
+
+Risk: low. Purely additive. If the backfill is incomplete (e.g., a proverb word doesn't match any `Word` row), the proverb still works as before; only the new "proverbs containing X" query is affected.
+
+## Phase 3a — NFC-Normalize Existing Proverb Text (Bug Fix)
+
+Discovered during Phase 3 implementation review: every runtime *write* path historically bypassed Unicode normalization in different ways, so existing data could be in mixed NFC/NFD forms. The Phase 3 proverb-words connection assumes consistent normalization to dedupe correctly, and the Phase 0 missing-translation upsert assumes consistent normalization on the read path to aggregate hits correctly.
+
+The runtime bug fixes are code-only:
+
+- New `normalize_word_text` and `normalize_text` helpers in `seed_data_utils`.
+- `add_proverb` normalizes `yoruba_text` and `english_text` before storage and before duplicate detection.
+- `is_valid_yoruba_word`, `is_valid_yoruba_text`, `is_valid_english_word`, and `is_valid_english_text` self-NFC-normalize input. Without this, NFD Yoruba input was rejected because the regex character class is NFC.
+- `translate()` and `translate_llm()` route input through `normalize_word_text` so reads against NFC-stored Word rows match NFD requests, and so `log_missing_translation` aggregates by canonical form.
+
+The data migration brings existing rows into NFC:
+
+1. Snapshot every Proverb row's original text into `_phase3a_pre_normalize_proverbs` (full audit trail).
+2. Group rows by their NFC pair. For groups with >1 row (NFC/NFD collisions), keep `min(p_id)` and log the rest into `_phase3a_removed_proverb_duplicates` before deleting them.
+3. UPDATE remaining rows to NFC.
+
+Risk: low for the schema impact, medium for the data destruction *if* normalization-collision duplicates exist. Operator preflight: count rows in `_phase3a_removed_proverb_duplicates` after staging before promoting to prod.
+
+Reversibility: text UPDATE is reversible from the snapshot; row DELETE is not. Downgrade fails loudly by default (same `ALARINO_FORCE_DOWNGRADE_DATA_LOSS=1` opt-in escape hatch as Phase 1 and Phase 2).
+
+## Phase 3b — Lock In Normalization Defenses (Defense in Depth)
+
+Phase 3a fixed the runtime drift and normalized existing data. Phase 3b makes future drift structurally harder to introduce. Rationale: every normalization bug we fixed in Phase 3a was an instance of "a writer forgot to call `normalize_word_text`." That pattern will recur unless the constraint moves out of call-site discipline and into a place where forgetting is impossible.
+
+No data migration. Code changes only.
+
+1. **SQLAlchemy `TypeDecorator` for canonical text columns.** Add a `NFCWord` (lowercase + strip + NFC, mirrors `normalize_word_text`) and `NFCText` (NFC + strip, mirrors `normalize_text`) TypeDecorator. Apply `NFCWord` to `Word.word` and `MissingTranslation.text`; apply `NFCText` to `Proverb.yoruba_text` and `Proverb.english_text`. The `process_bind_param` hook normalizes on every ORM write, so call sites can no longer skip it. Raw SQL still bypasses, but raw SQL into these tables is already a yellow flag worth flagging at code review.
+
+2. **Property tests for every text-touching API path.** For each of `add_word`, `add_proverb`, `translate`, `translate_llm`, `log_missing_translation`, `get_proverbs_containing`: assert that calling with NFC and NFD of the same Yoruba string produces byte-identical observable outcomes (same row count, same stored bytes, same query results). New text-handling code added later that breaks this property fails CI before it merges.
+
+3. **Schema integrity assertion.** Add a single CI check (or a smoke test that runs against staging) that runs:
+   ```sql
+   SELECT count(*) FROM words WHERE word != normalize(word, NFC);
+   SELECT count(*) FROM proverbs WHERE yoruba_text != normalize(yoruba_text, NFC) OR english_text != normalize(english_text, NFC);
+   SELECT count(*) FROM missing_translations WHERE text != normalize(text, NFC);
+   ```
+   All must return 0. Postgres has `unicode_normalize()` since PG13; the check runs in <1s on tables this size and surfaces drift before it propagates.
+
+Risk: very low. The TypeDecorator is a no-op when input is already canonical (which it will be after Phase 3a + the runtime fixes). Property tests and the integrity check are pure additions.
+
+Out of scope here (considered and rejected): a Postgres `CHECK (text = unicode_normalize(text, 'NFC'))` constraint diverges from SQLite test behavior and would require dialect-specific migration code; a `BEFORE INSERT` normalization trigger silently corrects bugs instead of surfacing them, which masks drift. The TypeDecorator gives the same guarantee at the ORM layer with neither downside.
+
+## Phase 3c — Agentic Enforcement (Process Defenses)
+
+Phase 3b puts the constraint in the type system; Phase 3c puts a second pair of eyes on every change that could subvert it. Phase 3a fixed six different drift bugs that all looked the same in retrospect ("a writer forgot to call `normalize_word_text`"). LLM review is a cheap way to catch the seventh one before it merges.
+
+These are tooling additions, not application code. Each item is independently shippable and independently removable.
+
+1. **PR-time normalization-reviewer subagent.** A GitHub Action (or equivalent CI step) that triggers on PRs touching `alarino_backend/src/alarino_backend/db_models.py`, `alarino_backend/src/alarino_backend/translation_service.py`, `alarino_backend/src/alarino_backend/data/seed_data_utils.py`, or any file under `alarino_backend/migrations/versions/`. The action calls a focused prompt: *"Given this diff, does it introduce or modify a code path that writes user text to a canonical column without routing through `normalize_word_text` / `normalize_text` / the `NFCWord` / `NFCText` TypeDecorator? Return specific file:line references, or 'clean' if none."* Posts a single PR comment with the verdict. Cost: a few cents per touched PR. Failure mode: false positives that reviewers can dismiss; far better than the false negative we already paid for in Phase 3a.
+
+2. **Scheduled drift-detection agent.** A daily `/schedule` job that connects to staging, runs the Phase 3b integrity queries, and opens a GitHub issue (with a sample of offending rows) if any return non-zero. Independent backstop for whatever slipped past the PR reviewer. Cost: one query per day per table; negligible.
+
+3. **Author-invoked review skill.** A `.claude/skills/normalization-review.md` skill definition that encodes the contract from this plan. Author runs `/normalization-review` against the working tree before pushing for any change that touches text-handling code. Catches what local linting can't reason about. Cost: zero until invoked.
+
+Sequencing: ship #1 first (catches the most cases at the right moment), #2 next (cheap insurance), #3 last (only worth defining once the contract from items #1-#2 is stable enough to encode in a skill).
+
+Out of scope here (considered and rejected): live request-time LLM inspection (too slow, redundant with the TypeDecorator that already runs on every write); LLM auto-fix that rewrites the diff (silent correction defeats the goal of surfacing intent — same reasoning as rejecting the DB-level normalization trigger in Phase 3b).
+
+Risk: very low. None of these touch production data or runtime code. Worst case is a noisy CI bot that reviewers ignore, which is recoverable by removing the action.
+
+## Phase 4 — Translation Directionality
+
+Moved earlier in the plan. The Translation identity model is foundational: `DailyWord` (Phase 5), the sense layer (Phase 6), and several read paths all reference `translations.t_id`. Settling whether `(A,B)` and `(B,A)` are one row or two before downstream tables start pointing at translations avoids a cascading remap later.
+
+One Alembic revision plus a service-layer change.
+
+Pick one of two approaches based on what current data looks like (run the inspection query as the first step of the phase):
+
+- **Option A (preferred): undirected canonical ordering.** Replace `unique_translation_pair (source_word_id, target_word_id)` with `unique_translation_pair_canonical (LEAST(source_word_id, target_word_id), GREATEST(...))`. Update insert paths to canonicalize before write. Update `translate()` to query both directions. **Migration is data-destructive**: existing reverse-pair duplicates must be consolidated. The consolidation step must remap every dependent FK (today: `examples.translation_id`; in future phases: `daily_words.translation_id`, sense-layer additions) to point at the surviving row before the duplicate is dropped. Removed rows are logged to `_phase4_consolidated_translations`. Conflicts (where the two pair rows disagree on attached examples) are surfaced for manual resolution and block the migration.
+- **Option B: enforce inverse on insert.** Keep directed storage, but wrap `create_translation` so inserting `(A, B)` always also inserts `(B, A)` in the same transaction. Add a periodic consistency check that verifies every translation has its inverse. No deletes, no FK remap, fully reversible.
+
+Decision criterion: run two preflight queries.
+
+1. Reverse-pair count:
+   ```sql
+   SELECT count(*)
+   FROM translations a
+   JOIN translations b
+     ON a.source_word_id = b.target_word_id
+    AND a.target_word_id = b.source_word_id
+   WHERE a.t_id < b.t_id;
+   ```
+2. Example-conflict landscape (lists every reverse pair with example counts on each side, so the operator can see which consolidations would require manual reconciliation):
+   ```sql
+   SELECT
+     a.t_id AS keep_t_id,
+     b.t_id AS drop_t_id,
+     (SELECT count(*) FROM examples WHERE translation_id = a.t_id) AS keep_examples,
+     (SELECT count(*) FROM examples WHERE translation_id = b.t_id) AS drop_examples
+   FROM translations a
+   JOIN translations b
+     ON a.source_word_id = b.target_word_id
+    AND a.target_word_id = b.source_word_id
+   WHERE a.t_id < b.t_id;
+   ```
+   Pairs where `drop_examples > 0` need their example rows remapped to `keep_t_id`. Pairs where both sides have non-empty, non-identical example sets must be reconciled manually before the migration runs.
+
+If the reverse-pair count is small and the example-conflict query returns no rows requiring manual reconciliation, go Option A. If either query reveals significant mess, go Option B and revisit later.
+
+Risk: medium for Option A (irreversible deletes plus FK remap), low for Option B.
+
+## Phase 5 — Normalize `DailyWord` to Reference `Translation`
+
+One Alembic revision. Depends on Phase 4 having settled the Translation identity model — under Option A, the canonical row is unambiguous; under Option B, both directions exist and either can be referenced.
+
+If Phase 4 chose **Option B** (directed pairs with enforced inverses), `daily_words.translation_id` may point at either the Yoruba→English row or the English→Yoruba row, since both exist and are equally valid references. **Read paths must derive the Yoruba and English sides by joining `Word` and inspecting `Word.language`, not by assuming `source_word_id` is Yoruba and `target_word_id` is English.** The current `get_word_of_the_day` code makes that positional assumption today and must be updated as part of this phase. Under Option A this caveat is moot — there is one canonical row and the language of each side is still recovered by joining `Word`.
+
+A daily word is conceptually a translation pair, but today `DailyWord` stores `word_id` and `en_word_id` as two independent FKs to `Word`. Nothing in the schema requires those two words to actually be a translation of each other. Replacing both columns with a single `translation_id` FK makes the relationship correct by construction.
+
+1. Add `DailyWord.translation_id` (nullable) FK → `translations.t_id`.
+2. Backfill: for each existing `DailyWord` row, find the matching `Translation` by querying both directions (`(word_id, en_word_id)` and `(en_word_id, word_id)`).
+3. **Stop the migration on integrity failure.** If any `DailyWord` row has no matching `Translation`, the migration aborts with a list of offending `dw_id` values. Rationale: a daily word that points at two unrelated words is corrupt input, not a row to launder by manufacturing a translation pair. The operator must either delete the bad daily word or insert the intended translation manually before re-running the migration. Do *not* silently create a translation, because doing so makes the corruption permanent and indistinguishable from real curated data.
+4. Update `translation_service.get_word_of_the_day` and any write paths to use `translation_id`.
+5. Make `translation_id` `NOT NULL`.
+6. Drop `word_id` and `en_word_id`.
+
+Risk: low for the schema change. The fail-loud backfill *is* the safety mechanism; expect the first run in staging to surface real integrity issues that need human review.
+
+## Phase 6 — Sense Layer (Core Restructure)
+
+The largest change. Multiple Alembic revisions across two release cycles, expand/contract throughout.
+
+### 6a — Add the sense layer alongside existing structure
+
+1. Add `senses` table:
+   - `sense_id` PK
+   - `word_id` FK → `words.w_id`
+   - `part_of_speech` (moved from `Word`, but kept on `Word` for now)
+   - `sense_label` (short disambiguator, e.g. "financial", "river")
+   - `definition` (Text, nullable)
+   - `register` (formal/colloquial/slang/archaic, nullable)
+   - `domain` (medical/legal/etc, nullable)
+   - `created_at` with proper defaults
+2. Add `translations.source_sense_id` and `translations.target_sense_id` (nullable initially), each FK to `senses`.
+3. Add metadata columns on `Translation`:
+   - `note` (Text, nullable)
+   - `confidence` (Float, nullable)
+   - `source` (String, nullable — e.g. `'curated'`, `'llm'`, `'community'`)
+4. Backfill: for every existing `Word`, create one `senses` row carrying that word's current `part_of_speech`. For every existing `Translation`, set `source_sense_id` and `target_sense_id` to those single senses.
+
+After 6a, the schema supports senses but nothing forces their use. Reads still work as before.
+
+### 6b — Cut writes over to senses
+
+1. Update `seed_data_utils` and `translation_service` write paths so new translations always create or reuse a `Sense` and reference it.
+2. Move `Example` to attach to a `(source_sense_id, target_sense_id)` pair instead of `translation_id`. Migrate existing rows by copying the now-known sense IDs from the parent translation. Keep `translation_id` on `Example` until 6d.
+
+### 6c — Cut reads over to senses
+
+1. Update `translate()` to return sense-grouped results (multiple senses → multiple result groups, each with its own translations and examples).
+2. Update API response shape behind a feature flag or a new endpoint version (`/api/v2/translate`). Old endpoint remains until the frontend cuts over.
+
+### 6d — Drop legacy
+
+1. Make `translations.source_sense_id` and `translations.target_sense_id` `NOT NULL`.
+2. Drop `Example.translation_id`.
+3. Drop `Word.part_of_speech`.
+4. Remove the v1 translate endpoint once frontend traffic is fully on v2.
+
+Risk: medium. The expand/contract pattern keeps each step reversible until 6d, but the API change in 6c is user-visible. Coordinate with the frontend.
+
+## Phase 7 — Rename `word` to `text`
+
+One Alembic revision, expand/contract.
+
+1. Add `Word.text` column, copy `word` into it, set `NOT NULL`.
+2. Recreate `unique_language_word` as `unique_language_text` on `(language, text)`.
+3. Update all reads to use `text`.
+4. Drop `word`.
+
+Risk: low. Deferred to last so it doesn't entangle with sense-layer work.
+
+## Out of Scope (Possible Follow-Ups)
+
+- **Multilingual conversion.** Replace `Proverb.yoruba_text`/`english_text` with `proverb_translations(proverb_id, language, text)`, broaden the language CHECK constraint, and replace `is_valid_yoruba_word` / `is_valid_english_word` with a generic per-language validator registry. Only worth doing if a third language is on the roadmap. (`DailyWord` is already covered by Phase 5.)
+- **Per-request telemetry.** Add a `missing_translation_events(text, source, target, requested_at, ...)` append-only table to capture the "who asked, when" signal that `user_ip` was vaguely gesturing at. Distinct from the aggregated `missing_translations` row, which keeps its role as the unique-per-tuple counter.
+- **Pronunciation, audio, IPA, tags, lemma/inflection model.** All additive; no current blocker.
+- **Edit history and contributor identity.** Requires an auth model first.
+
+## Testing Expectations
+
+- Every phase adds tests covering: the new constraint or column behavior, the backfill correctness on representative fixture data, and a regression test for any read path whose query changed.
+- Each migration is exercised both forward and back (`alembic upgrade head && alembic downgrade -1 && alembic upgrade head`) in CI. Phases with explicitly non-reversible steps (Phase 1 step 3, Phase 2 user_ip drop, Phase 4 Option A consolidation, Phase 6d) test forward-only and assert that downgrade fails cleanly with a clear message rather than silently leaving the schema half-migrated.
+- Phase 4 adds a property test matched to the chosen option:
+  - Option A: inserting `(A, B)` and `(B, A)` through the public service path produces exactly one row, and `translate()` returns the same translation regardless of query direction.
+  - Option B: inserting `(A, B)` produces both `(A, B)` and `(B, A)` in the same transaction; the consistency-check job finds zero orphans on a representative fixture.
+- Phase 6 adds a property test: a polysemous word (e.g. "bank") with two senses and two distinct target translations returns two grouped result sets from `translate()`, each with its own examples — verifying the sense layer is actually load-bearing and not just structurally present.

--- a/docs/plans/schema_evolution_plan.md
+++ b/docs/plans/schema_evolution_plan.md
@@ -163,52 +163,33 @@ Out of scope here (considered and rejected): live request-time LLM inspection (t
 
 Risk: very low. None of these touch production data or runtime code. Worst case is a noisy CI bot that reviewers ignore, which is recoverable by removing the action.
 
-## Phase 4 — Translation Directionality
+## Phase 4 — Bidirectional Translation Lookup
 
-Moved earlier in the plan. The Translation identity model is foundational: `DailyWord` (Phase 5), the sense layer (Phase 6), and several read paths all reference `translations.t_id`. Settling whether `(A,B)` and `(B,A)` are one row or two before downstream tables start pointing at translations avoids a cascading remap later.
+**Decision (recorded after design discussion):** keep `Translation` as a directed edge (one row per curated direction, no auto-mirror) and fix the *lookup* code to query both columns. This was chosen over the originally-considered alternatives (canonical undirected storage with consolidation; auto-creating the inverse on every insert) because it preserves curatorial intent — the schema honestly records what was added in which direction — while still giving users a "translations are symmetric" experience.
 
-One Alembic revision plus a service-layer change.
+The bug being fixed: today `translate()` filters only on `source_word_id`. A row `(en:hello → yo:bawo)` makes `translate("hello", en→yo)` work, but `translate("bawo", yo→en)` returns "translation not available" even though the data is right there. Verified end-to-end in the Phase 3a Docker validation (test G3): bulk-upload created the en→yo direction only, and the yo→en lookup failed.
 
-Pick one of two approaches based on what current data looks like (run the inspection query as the first step of the phase):
+No schema change. No migration. No new constraints. One service-layer change plus tests.
 
-- **Option A (preferred): undirected canonical ordering.** Replace `unique_translation_pair (source_word_id, target_word_id)` with `unique_translation_pair_canonical (LEAST(source_word_id, target_word_id), GREATEST(...))`. Update insert paths to canonicalize before write. Update `translate()` to query both directions. **Migration is data-destructive**: existing reverse-pair duplicates must be consolidated. The consolidation step must remap every dependent FK (today: `examples.translation_id`; in future phases: `daily_words.translation_id`, sense-layer additions) to point at the surviving row before the duplicate is dropped. Removed rows are logged to `_phase4_consolidated_translations`. Conflicts (where the two pair rows disagree on attached examples) are surfaced for manual resolution and block the migration.
-- **Option B: enforce inverse on insert.** Keep directed storage, but wrap `create_translation` so inserting `(A, B)` always also inserts `(B, A)` in the same transaction. Add a periodic consistency check that verifies every translation has its inverse. No deletes, no FK remap, fully reversible.
+**Implementation:**
 
-Decision criterion: run two preflight queries.
+1. In `translation_service.translate()`, change the Translation query from "source_word_id = X" to "source_word_id = X OR target_word_id = X". For each match, return the *other* word — `target_word` if the lookup matched the source side, `source_word` if it matched the target side. Filter the "other word" by the requested target language and dedupe by `w_id` so a pair curated in both directions doesn't return the same Yoruba word twice.
+2. Add a `direction` field on `TranslationResponseData` (or similar — final shape TBD) so the frontend can distinguish results from the curated direction vs the implicit reverse, if it ever wants to surface that. Default presentation is identical regardless.
+3. No write-path changes. `create_translation` keeps its current single-direction semantics. Contributors who want both directions explicitly can add both rows; nothing requires them to.
 
-1. Reverse-pair count:
-   ```sql
-   SELECT count(*)
-   FROM translations a
-   JOIN translations b
-     ON a.source_word_id = b.target_word_id
-    AND a.target_word_id = b.source_word_id
-   WHERE a.t_id < b.t_id;
-   ```
-2. Example-conflict landscape (lists every reverse pair with example counts on each side, so the operator can see which consolidations would require manual reconciliation):
-   ```sql
-   SELECT
-     a.t_id AS keep_t_id,
-     b.t_id AS drop_t_id,
-     (SELECT count(*) FROM examples WHERE translation_id = a.t_id) AS keep_examples,
-     (SELECT count(*) FROM examples WHERE translation_id = b.t_id) AS drop_examples
-   FROM translations a
-   JOIN translations b
-     ON a.source_word_id = b.target_word_id
-    AND a.target_word_id = b.source_word_id
-   WHERE a.t_id < b.t_id;
-   ```
-   Pairs where `drop_examples > 0` need their example rows remapped to `keep_t_id`. Pairs where both sides have non-empty, non-identical example sets must be reconciled manually before the migration runs.
+**Tests:**
 
-If the reverse-pair count is small and the example-conflict query returns no rows requiring manual reconciliation, go Option A. If either query reveals significant mess, go Option B and revisit later.
+- Property test: insert a single `(en:hello → yo:bawo)` row through the public API; `translate("hello", en→yo)` returns `["bawo"]`; `translate("bawo", yo→en)` returns `["hello"]`. Both directions resolve from the one curated row.
+- Dedup test: insert both `(en:hello → yo:bawo)` and `(yo:bawo → en:hello)`; lookup in either direction returns each translation exactly once.
+- Negative test: empty translations table → both directions return "translation not available."
 
-Risk: medium for Option A (irreversible deletes plus FK remap), low for Option B.
+Risk: very low. No schema change, no migration, no data destruction. The only behavioral change is that lookups that previously returned 404 because only the inverse was curated will now return 200. That's the intended fix.
 
 ## Phase 5 — Normalize `DailyWord` to Reference `Translation`
 
-One Alembic revision. Depends on Phase 4 having settled the Translation identity model — under Option A, the canonical row is unambiguous; under Option B, both directions exist and either can be referenced.
+One Alembic revision.
 
-If Phase 4 chose **Option B** (directed pairs with enforced inverses), `daily_words.translation_id` may point at either the Yoruba→English row or the English→Yoruba row, since both exist and are equally valid references. **Read paths must derive the Yoruba and English sides by joining `Word` and inspecting `Word.language`, not by assuming `source_word_id` is Yoruba and `target_word_id` is English.** The current `get_word_of_the_day` code makes that positional assumption today and must be updated as part of this phase. Under Option A this caveat is moot — there is one canonical row and the language of each side is still recovered by joining `Word`.
+Phase 4 settled on directed storage with bidirectional lookup (no auto-mirror). That means a `Translation` row may have its source and target columns in either language order — whichever direction the curator originally added. **Read paths must derive the Yoruba and English sides by joining `Word` and inspecting `Word.language`, not by assuming `source_word_id` is Yoruba and `target_word_id` is English.** The current `get_word_of_the_day` code makes that positional assumption today and must be updated as part of this phase.
 
 A daily word is conceptually a translation pair, but today `DailyWord` stores `word_id` and `en_word_id` as two independent FKs to `Word`. Nothing in the schema requires those two words to actually be a translation of each other. Replacing both columns with a single `translation_id` FK makes the relationship correct by construction.
 
@@ -285,8 +266,6 @@ Risk: low. Deferred to last so it doesn't entangle with sense-layer work.
 ## Testing Expectations
 
 - Every phase adds tests covering: the new constraint or column behavior, the backfill correctness on representative fixture data, and a regression test for any read path whose query changed.
-- Each migration is exercised both forward and back (`alembic upgrade head && alembic downgrade -1 && alembic upgrade head`) in CI. Phases with explicitly non-reversible steps (Phase 1 step 3, Phase 2 user_ip drop, Phase 4 Option A consolidation, Phase 6d) test forward-only and assert that downgrade fails cleanly with a clear message rather than silently leaving the schema half-migrated.
-- Phase 4 adds a property test matched to the chosen option:
-  - Option A: inserting `(A, B)` and `(B, A)` through the public service path produces exactly one row, and `translate()` returns the same translation regardless of query direction.
-  - Option B: inserting `(A, B)` produces both `(A, B)` and `(B, A)` in the same transaction; the consistency-check job finds zero orphans on a representative fixture.
+- Each migration is exercised both forward and back (`alembic upgrade head && alembic downgrade -1 && alembic upgrade head`) in CI. Phases with explicitly non-reversible steps (Phase 1 step 3, Phase 2 user_ip drop, Phase 3a duplicate consolidation, Phase 6d) test forward-only and assert that downgrade fails cleanly with a clear message rather than silently leaving the schema half-migrated. (Phase 4 has no migration.)
+- Phase 4 adds property tests for bidirectional lookup: a single curated `(en:hello → yo:bawo)` row makes `translate("hello", en→yo)` and `translate("bawo", yo→en)` both succeed; curating both directions returns each translation exactly once (dedup); empty translations table returns "translation not available" in both directions.
 - Phase 6 adds a property test: a polysemous word (e.g. "bank") with two senses and two distinct target translations returns two grouped result sets from `translate()`, each with its own examples — verifying the sense layer is actually load-bearing and not just structurally present.


### PR DESCRIPTION
## Summary

Lands the full schema evolution plan documented in [`docs/plans/schema_evolution_plan.md`](docs/plans/schema_evolution_plan.md). Restructures the alarino database from a flat word-pair store into a real bilingual dictionary schema (Word → Sense → Translation), fixes a handful of correctness bugs surfaced along the way, and locks in normalization defenses so future drift is structurally harder. 16 commits, 13 alembic migrations, 144 tests passing, 76% overall coverage.

Each phase is a distinct commit in case you want to step through them; the messages explain the rationale per phase.

## What changed (by phase)

**Bug fixes:**
- **Phase 0** — `Word.created_at` default was `datetime.now()` (called once at import); switched to the callable. `log_missing_translation` was a racy read-modify-write; replaced with an atomic `INSERT … ON CONFLICT DO UPDATE` (PG and SQLite dialect dispatch).
- **Phase 1** — Dropped 5 redundant indexes covered by unique constraints; tightened every `created_at` to NOT NULL with `server_default`; deduped `examples` and added a unique constraint. Sidecar audit table preserves removed rows.

**Hygiene + telemetry cleanup:**
- **Phase 2** — `CHECK (language IN ('en','yo'))` on `Word` and `MissingTranslation`. Dropped `MissingTranslation.user_ip` (after the Phase 0 upsert change it was meaningless — only ever held the first asker per tuple). Sidecar audit retains the dropped values.

**Proverb-vocabulary connection + normalization defenses:**
- **Phase 3** — New `proverb_words(proverb_id, word_id, language, position)` join table. Backfill mirrors runtime tokenizer (NFC + lowercase + strip + the same Yoruba/English validators).
- **Phase 3a** — Audited every text-touching path; six bypassed normalization. Extracted `normalize_word_text` / `normalize_text` into a no-DB module; `add_proverb`, all four `is_valid_*` validators, `translate()`, `translate_llm()`, and `get_proverbs_containing()` now route through them. Data migration NFC-normalizes existing proverb rows (with collision-dedup + sidecar).
- **Phase 3b** — Defense in depth: `NFCWord` and `NFCText` `TypeDecorator`s on canonical text columns normalize at SQLAlchemy bind time, including for query parameters. New `audit_normalization_integrity()` helper for periodic drift detection.

**Bidirectional translation:**
- **Phase 4** — Translation kept as a directed edge (no auto-mirror — preserves curatorial intent), but `translate()` now queries both `source_word_id` and `target_word_id` and dedupes by `w_id`. A single curated en→yo row makes both directions resolve.

**DailyWord normalization:**
- **Phase 5** — Replaced `DailyWord.word_id` + `en_word_id` (two unrelated FKs) with a single `translation_id` FK. Read paths derive Yoruba/English sides via `Word.language` joins, never positional source/target. Migration aborts with offending row IDs if any DailyWord references two unrelated words.

**Sense layer (the big restructure):**
- **Phase 6a** — Add `senses` table + nullable sense FKs and metadata (note, confidence, provenance) on Translation; backfill one Sense per existing Word. Purely additive.
- **Phase 6b** — Cut writes over: `create_translation` now populates sense FKs via `_ensure_default_sense`. Examples gain sense FK columns, backfilled from parent Translation.
- **Phase 6b POS-check** — Typed `PartOfSpeech` enum (11 short codes) + CHECK constraints on `Word.part_of_speech` and `Sense.part_of_speech`.
- **Phase 6c** — `/api/translate` response gains an additive `senses` array (legacy `translation` flat list unchanged for backward compatibility). Polysemous words like `bank` (financial vs river) surface as distinct sense groups with their own metadata.
- **Phase 6d** — Drop legacy: `Translation` sense FKs become NOT NULL, `Example.translation_id` dropped, `Word.part_of_speech` dropped (POS lives only on Sense).

**Final polish:**
- **Phase 7** — Renamed `Word.word` column to `Word.text` (the long-standing `##todo` in the model). Code rename across translation_service, normalization audit, seed_data_utils, sitemap generator, and tests.
- **Phase 7 bug-fix** — Three issues surfaced from review of the cutover:
  - **P1a:** `DailyWord.translation_id` UNIQUE collided with `find_random_unused_translation`'s default reuse, 500'ing on the second daily-word call against a single-translation DB. Removed the constraint; date uniqueness still enforces one daily word per date.
  - **P1b:** `unique_translation_pair` on `(source_word_id, target_word_id)` blocked the polysemy the sense layer was meant to unlock. Replaced with `unique_translation_sense_pair` on `(source_sense_id, target_sense_id)`; added back `idx_translations_source_word_id`.
  - **P2:** `_ensure_default_sense` silently bound new translations to the lowest-`sense_id` sense when a word had multiple. Now raises `AmbiguousSenseError` so callers either pick a sense or surface the ambiguity.

**Repo plumbing:**
- Bulk-upload integration tests (10 new, lifted `translation_service.py` coverage from 71% → 89%).
- Added `pytest-cov` to dev deps.
- Tracked `AGENTS.md` (project conventions: use the `alarino` conda env) + `CLAUDE.md` symlink.

## Migration safety story

- Every migration is reviewable on its own and was exercised forward + back against SQLite during development.
- Final state verified end-to-end against real Postgres in Docker after each phase.
- Data-destructive steps (Phase 1 example dedup, Phase 2 user_ip drop, Phase 3a proverb dedup, Phase 6d column drops, Phase 5 fail-loud backfill) all have:
  - A built-in preflight that aborts with offending row IDs when the upgrade would silently corrupt data.
  - Sidecar audit tables (`_phase1_…`, `_phase2_…`, `_phase3a_…`) preserving removed rows.
  - Downgrade that fails loudly by default; opt-in `ALARINO_FORCE_DOWNGRADE_DATA_LOSS=1` for the partial reversal that operators who explicitly accept the loss can use.

Operator preflight notes are inlined in each migration's docstring.

## Test plan

- [x] `pytest -q` — 144 tests pass via the `alarino` conda env
- [x] `pytest --cov=alarino_backend` — 76% overall, 89% on `translation_service.py`, 92%+ on the model and normalization modules
- [x] All 13 migrations apply cleanly forward against a fresh Postgres 16 in Docker
- [x] Each migration's downgrade verified (with the documented opt-in for data-destructive ones)
- [x] End-to-end API smoke against real Postgres for every phase: bulk-upload, translate (forward + reverse direction), daily-word, proverb endpoints all behave as expected
- [x] Polysemy proof-of-concept: a `bank` word with curated `financial` + `river` senses returns two distinct sense groups in the `/api/translate` response
- [x] NFC/NFD collapse proof: `POST /api/translate` with NFD `ọmọ` and NFC `ọmọ` produces one `missing_translations` row with `hit_count=2` (raw hex bytes confirmed canonical NFC)

## Reviewer notes

- The plan ([`docs/plans/schema_evolution_plan.md`](docs/plans/schema_evolution_plan.md)) is the best reading order for understanding the *why*; commit messages cover the *how*.
- Phase 6c is API-additive (new `senses` field), not a breaking change. Existing clients reading `data.translation` continue to work unchanged.
- POS data is mostly NULL today; the `PartOfSpeech` enum + CHECK constraints set the contract for when curation does start filling it in.
- Sidecar `_phase*_…` tables are safe to drop manually after each migration is confirmed stable in prod; they're explicitly preserved on downgrade so operators can recover.