### PR TITLE
Make migrations actually persist + run flask db upgrade in deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -101,7 +101,19 @@ jobs:
             docker image prune -f || true
             docker container prune -f || true
 
-            echo "Rebuilding and restarting caddy + frontend + backend..."
+            echo "Building backend image (so the new alembic revisions are available)..."
+            docker compose -f docker-compose.yml -f docker-compose.prod.yml build backend
+
+            echo "Running database migrations against the live DB using the new image..."
+            # One-shot container using the freshly-built backend image. If a
+            # migration aborts (any preflight fires on real prod data), this
+            # exits non-zero and the script halts under set -e — the OLD
+            # backend container keeps serving traffic against the OLD schema
+            # until the data issue is resolved and the deploy is re-run.
+            docker compose -f docker-compose.yml -f docker-compose.prod.yml run --rm backend \
+              python -m flask --app alarino_backend.app:create_app db upgrade head
+
+            echo "Rebuilding (no-op cache hit) and restarting caddy + frontend + backend..."
             docker compose -f docker-compose.yml -f docker-compose.prod.yml up --build -d backend frontend caddy
 
             echo "Deployment complete."

--- a/alarino_backend/migrations/env.py
+++ b/alarino_backend/migrations/env.py
@@ -97,6 +97,14 @@ def run_migrations_online():
     connectable = get_engine()
 
     with connectable.connect() as connection:
+        # Set a short lock_timeout on Postgres so a migration that can't
+        # immediately acquire AccessExclusive on a live table aborts cleanly
+        # (no deadlock; transaction rolls back) and can be retried, instead
+        # of blocking indefinitely or being chosen as the deadlock victim.
+        # SQLite has no equivalent and ignores this.
+        if connection.dialect.name == 'postgresql':
+            connection.exec_driver_sql("SET lock_timeout = '5s'")
+
         context.configure(
             connection=connection,
             target_metadata=get_metadata(),
@@ -105,6 +113,18 @@ def run_migrations_online():
 
         with context.begin_transaction():
             context.run_migrations()
+
+        # SQLAlchemy 2.x + Flask-SQLAlchemy 3.x: connection.connect() returns
+        # a connection in autobegin mode and alembic's begin_transaction does
+        # not commit at the connection level under that configuration. Without
+        # this explicit commit the migration writes (including the
+        # alembic_version update) appear in the same connection but get
+        # rolled back when the connection is returned to the pool. Manifested
+        # as "flask db upgrade exits 0 silently with no schema change"
+        # against a Neon Postgres backend; verified the same pattern hits
+        # the local Postgres path too.
+        if connection.in_transaction():
+            connection.commit()
 
 
 if context.is_offline_mode():

--- a/alarino_backend/migrations/versions/f0e8d3a4c612_phase7_bugfix_polysemy_and_dailyword_reuse.py
+++ b/alarino_backend/migrations/versions/f0e8d3a4c612_phase7_bugfix_polysemy_and_dailyword_reuse.py
@@ -60,24 +60,14 @@ def upgrade():
             unique=False,
         )
 
-    # ---- DailyWord: drop uniqueness on translation_id ----
-    # SQLite stored the unique=True column as a constraint named
-    # "daily_words_translation_id_key" or similar via SQLAlchemy. To handle
-    # both the SQLAlchemy-default name and the Postgres-default name
-    # portably, drop via batch_alter_table.alter_column with unique=False.
-    with op.batch_alter_table("daily_words", schema=None) as batch_op:
-        batch_op.drop_constraint(
-            "unique_daily_words_translation_id", type_="unique"
-        )
+    # NOTE: an earlier draft of this migration also dropped a UNIQUE
+    # constraint on daily_words.translation_id. That constraint was
+    # originally added by Phase 5, but Phase 5 has since been amended to
+    # never add it (it conflicted with prod data that already had repeat
+    # translation_ids across dates). Nothing to drop here.
 
 
 def downgrade():
-    with op.batch_alter_table("daily_words", schema=None) as batch_op:
-        batch_op.create_unique_constraint(
-            "unique_daily_words_translation_id",
-            ["translation_id"],
-        )
-
     with op.batch_alter_table("translations", schema=None) as batch_op:
         batch_op.drop_index("idx_translations_source_word_id")
         batch_op.drop_constraint(

--- a/alarino_backend/migrations/versions/f6a182cd9e07_phase5_dailyword_translation_id.py
+++ b/alarino_backend/migrations/versions/f6a182cd9e07_phase5_dailyword_translation_id.py
@@ -102,16 +102,17 @@ def upgrade():
             "that would launder the corruption into accepted curated data."
         )
 
-    # ---- Step 3: tighten translation_id, add unique constraint, drop old columns ----
+    # ---- Step 3: tighten translation_id and drop old columns ----
+    # Note: an earlier draft also added UNIQUE on translation_id here, but
+    # that conflicted with find_random_unused_translation's default
+    # can_reuse=True path AND with prod data that already had repeat
+    # translation_ids across dates. The Phase 7 bug-fix migration's
+    # rationale applies retroactively; we never add the constraint at all.
     with op.batch_alter_table("daily_words", schema=None) as batch_op:
         batch_op.alter_column(
             "translation_id",
             existing_type=sa.Integer(),
             nullable=False,
-        )
-        batch_op.create_unique_constraint(
-            "unique_daily_words_translation_id",
-            ["translation_id"],
         )
         batch_op.drop_column("en_word_id")
         batch_op.drop_column("word_id")


### PR DESCRIPTION
## Summary

Two related fixes that came out of running PR #33's migrations against prod for the first time. Both are about "the migration pipeline actually works end-to-end."

### 1. Make `flask db upgrade` actually persist (cherry-pick of `c3fc38d`)

When applying PR #33's migration chain to prod, `flask db upgrade head` reported success and the in-session diagnostics showed `alembic_version` advancing to head — but a fresh connection saw the original revision. The transaction was being silently rolled back when the connection returned to the pool.

Root cause: SQLAlchemy 2.x + Flask-SQLAlchemy 3.x + Postgres. `connection.connect()` returns a connection in autobegin mode. Alembic's `begin_transaction()` context manager does NOT actually commit at the connection level under that configuration. Without an explicit commit, the migration writes appear in-session but get rolled back on connection close.

Fix in `migrations/env.py`:
- After `with context.begin_transaction(): context.run_migrations()`, probe `connection.in_transaction()` and call `connection.commit()` explicitly if needed.
- Also added `SET lock_timeout = '5s'` on the Postgres connection so a future migration that can't immediately acquire `AccessExclusive` on a live table aborts cleanly (and can be retried) instead of being chosen as the deadlock victim.

Plus two paired migration corrections:
- **Phase 5** (`f6a182cd9e07`) — no longer adds the `unique_daily_words_translation_id` constraint. The original Phase 5 added it; the Phase 7 bug-fix later removed it. But against prod data with pre-existing repeat `translation_id`s across dates, Phase 5's `CREATE UNIQUE INDEX` failed before the chain could reach the bug-fix. Editing Phase 5 to never add the constraint (and the bug-fix to no longer try to drop it) makes the chain apply cleanly forward against any data shape consistent with the final design.
- **Phase 7 bug-fix** (`f0e8d3a4c612`) — the matching `drop_constraint` is removed.

### 2. Run `flask db upgrade head` in the deploy

The current deploy does `git pull` → tag rollback → `docker compose up`. No migration step. New backend code that depends on schema changes (the entire sense layer, the `word`→`text` rename, etc.) crashes on first request against the old schema until someone manually runs the migration.

Adds a step between "build the new backend image" and "swap the running container":

```bash
docker compose ... build backend
docker compose ... run --rm backend \
  python -m flask --app alarino_backend.app:create_app db upgrade head
docker compose ... up --build -d backend frontend caddy
```

If the migration aborts (preflight catches a data integrity issue, etc.), `set -e` halts the script and the OLD backend keeps serving against the OLD schema. No partial deploy state.

## Why both in one PR

Either fix without the other is incomplete:
- The deploy step would silently no-op without the env.py commit fix (the migration would "succeed" with nothing applied).
- The env.py fix alone leaves every future schema-touching deploy as a manual fire-fight.

## Test plan

- [x] 144 unit tests pass via the `alarino` conda env
- [x] Migration verified end-to-end against the prod Neon Postgres DB earlier today: full chain `1233050fe93a` → `f0e8d3a4c612` applied; `senses` table created; `words.text` column present; `words.word` and `words.part_of_speech` absent; prod `/api/health` returns 200; prod `/api/translate` returns the new sense-grouped response shape with valid data
- [ ] Next deploy will exercise the new `db upgrade head` step against an already-at-head DB (should be a fast no-op)

## Reviewer notes

- The `connection.commit()` fix is essential for any future migration. Without it, every `flask db upgrade` (including the new deploy step) would silently no-op on Postgres.
- The `lock_timeout = '5s'` is defensive — relevant when migrations race with a live backend's short-lived locks.
- The Phase 5 / Phase 7-bugfix corrections are functionally equivalent on a fresh DB but cleaner and safer against any data shape.