### PR TITLE
Fix mobile keyboard: cursor focus loss & duplicate ABC key

### DIFF
--- a/frontend/components/keyboard/keyboard.test.tsx
+++ b/frontend/components/keyboard/keyboard.test.tsx
@@ -12,6 +12,7 @@ import {
   useKeyboardText,
 } from "./keyboard-chrome";
 import { KeyboardDesigns } from "./keyboard-designs";
+import { NUM_LAYOUT } from "./mobile-keyboard";
 import { pickAlign, popoverAlignClass } from "./popover-align";
 import { hasTones, retoneSuffix, toneVariants, vowelAccents } from "./tones";
 
@@ -441,6 +442,13 @@ describe("layout geometry (muscle memory)", () => {
       expect(tokens(DVORAK_LAYOUT.yo.default)).toContain(special);
     }
   });
+
+  it("the numbers layout has exactly one ABC-return key", () => {
+    const abcRows = NUM_LAYOUT.filter((r) => r.split(/\s+/).includes("{abc}"));
+    expect(abcRows).toHaveLength(1);
+    // it lives on the bottom row, where every layout's return key sits
+    expect(NUM_LAYOUT[NUM_LAYOUT.length - 1]).toContain("{abc}");
+  });
 });
 
 describe("mobile keyboard — text field, blank key & tone strip", () => {
@@ -491,6 +499,18 @@ describe("mobile keyboard — text field, blank key & tone strip", () => {
     });
   });
 
+  it("offers only low and high tone keys (mid is the typed default)", async () => {
+    await renderMobile();
+    const strip = screen.getByRole("group", { name: "Tone marks" });
+    const buttons = strip.querySelectorAll("button");
+    expect(buttons).toHaveLength(2);
+    expect(toneButton(/low tone/i)).toBeInTheDocument();
+    expect(toneButton(/high tone/i)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /mid tone/i }),
+    ).not.toBeInTheDocument();
+  });
+
   it("retones the vowel before the caret and replaces (never stacks)", async () => {
     const ta = await renderMobile();
     seed(ta, "ko");
@@ -502,9 +522,10 @@ describe("mobile keyboard — text field, blank key & tone strip", () => {
     fireEvent.click(toneButton(/low tone/i));
     await waitFor(() => expect(ta).toHaveValue("kò"));
 
+    // switching back to high replaces the low mark rather than stacking
     ta.setSelectionRange(ta.value.length, ta.value.length);
-    fireEvent.click(toneButton(/mid tone/i));
-    await waitFor(() => expect(ta).toHaveValue("ko"));
+    fireEvent.click(toneButton(/high tone/i));
+    await waitFor(() => expect(ta).toHaveValue("kó"));
   });
 
   it("retones a sub-dot vowel using its combining form", async () => {

--- a/frontend/components/keyboard/keyboard.test.tsx
+++ b/frontend/components/keyboard/keyboard.test.tsx
@@ -499,16 +499,13 @@ describe("mobile keyboard — text field, blank key & tone strip", () => {
     });
   });
 
-  it("offers only low and high tone keys (mid is the typed default)", async () => {
+  it("offers low, mid and high tone keys", async () => {
     await renderMobile();
     const strip = screen.getByRole("group", { name: "Tone marks" });
-    const buttons = strip.querySelectorAll("button");
-    expect(buttons).toHaveLength(2);
+    expect(strip.querySelectorAll("button")).toHaveLength(3);
     expect(toneButton(/low tone/i)).toBeInTheDocument();
+    expect(toneButton(/mid tone/i)).toBeInTheDocument();
     expect(toneButton(/high tone/i)).toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: /mid tone/i }),
-    ).not.toBeInTheDocument();
   });
 
   it("retones the vowel before the caret and replaces (never stacks)", async () => {
@@ -522,10 +519,10 @@ describe("mobile keyboard — text field, blank key & tone strip", () => {
     fireEvent.click(toneButton(/low tone/i));
     await waitFor(() => expect(ta).toHaveValue("kò"));
 
-    // switching back to high replaces the low mark rather than stacking
+    // mid clears the mark in place — the only way to revert an accent
     ta.setSelectionRange(ta.value.length, ta.value.length);
-    fireEvent.click(toneButton(/high tone/i));
-    await waitFor(() => expect(ta).toHaveValue("kó"));
+    fireEvent.click(toneButton(/mid tone/i));
+    await waitFor(() => expect(ta).toHaveValue("ko"));
   });
 
   it("retones a sub-dot vowel using its combining form", async () => {

--- a/frontend/components/keyboard/mobile-keyboard.tsx
+++ b/frontend/components/keyboard/mobile-keyboard.tsx
@@ -42,10 +42,12 @@ const SPECIAL_BUTTONS = "ẹ ọ ṣ gb Ẹ Ọ Ṣ GB";
 // (no 400ms hold) is on the critical path for half of all typing. The
 // glyphs are a dotted circle (U+25CC) carrying the combining mark so
 // the diacritic shows in isolation. Long-press stays as a fallback.
-// Only low and high are offered — mid is the unmarked default you get
-// by simply typing the vowel, so a dedicated mid key has nothing to do.
+// Mid is kept as a dedicated key: it's the only in-place way to clear
+// an accidental accent — typing the bare vowel only helps before a
+// tone has been applied, not to revert kó/kò back to ko.
 const TONE_KEYS: { label: string; aria: string; index: ToneIndex }[] = [
   { label: "◌̀", aria: "Low tone (grave) on the last vowel", index: 0 },
+  { label: "◌", aria: "Mid tone (clear the mark) on the last vowel", index: 1 },
   { label: "◌́", aria: "High tone (acute) on the last vowel", index: 2 },
 ];
 
@@ -370,7 +372,7 @@ export function MobileKeyboard({ yo, en }: MobileKeyboardProps) {
           <div
             role="group"
             aria-label="Tone marks"
-            className="mx-auto grid w-full max-w-[480px] grid-cols-2 gap-1.5 px-2 pt-2"
+            className="mx-auto grid w-full max-w-[480px] grid-cols-3 gap-1.5 px-2 pt-2"
           >
             {TONE_KEYS.map((t) => (
               <button

--- a/frontend/components/keyboard/mobile-keyboard.tsx
+++ b/frontend/components/keyboard/mobile-keyboard.tsx
@@ -25,10 +25,12 @@ export type MobileKeyboardProps = KeyboardLayoutSet;
 type Lang = "yo" | "en";
 type Mode = "abc" | "num";
 
-const NUM_LAYOUT: string[] = [
+// Exported for layout tests. Row 3 deliberately has no {abc}: the only
+// "letters" return key is on row 4, where it sits in every layout.
+export const NUM_LAYOUT: string[] = [
   "1 2 3 4 5 6 7 8 9 0",
   "- / : ; ( ) ₦ & @ \"",
-  "{abc} . , ? ! ' {bksp}",
+  ". , ? ! ' {bksp}",
   "{abc} {space} {enter}",
 ];
 
@@ -40,9 +42,10 @@ const SPECIAL_BUTTONS = "ẹ ọ ṣ gb Ẹ Ọ Ṣ GB";
 // (no 400ms hold) is on the critical path for half of all typing. The
 // glyphs are a dotted circle (U+25CC) carrying the combining mark so
 // the diacritic shows in isolation. Long-press stays as a fallback.
+// Only low and high are offered — mid is the unmarked default you get
+// by simply typing the vowel, so a dedicated mid key has nothing to do.
 const TONE_KEYS: { label: string; aria: string; index: ToneIndex }[] = [
   { label: "◌̀", aria: "Low tone (grave) on the last vowel", index: 0 },
-  { label: "◌", aria: "Mid tone (no mark) on the last vowel", index: 1 },
   { label: "◌́", aria: "High tone (acute) on the last vowel", index: 2 },
 ];
 
@@ -367,18 +370,18 @@ export function MobileKeyboard({ yo, en }: MobileKeyboardProps) {
           <div
             role="group"
             aria-label="Tone marks"
-            className="mx-auto grid w-full max-w-[480px] grid-cols-3 gap-1.5 px-2 pt-2"
+            className="mx-auto grid w-full max-w-[480px] grid-cols-2 gap-1.5 px-2 pt-2"
           >
             {TONE_KEYS.map((t) => (
               <button
                 key={t.aria}
                 type="button"
                 aria-label={t.aria}
-                // Don't let the tap steal focus from the textarea —
-                // retoneLast reads selectionStart, and the caret needs
-                // to stay visible. Mirrors react-simple-keyboard's
-                // preventMouseDownDefault on the main key grid.
-                onMouseDown={(e) => e.preventDefault()}
+                // Prevent the tap (mouse OR touch) from stealing focus
+                // from the textarea — onPointerDown covers touch, where
+                // onMouseDown fires too late. Keeps the caret visible
+                // and retoneLast's selectionStart read accurate.
+                onPointerDown={(e) => e.preventDefault()}
                 onClick={() => {
                   tick();
                   retoneLast(t.index);


### PR DESCRIPTION
Follow-up fixes on top of the keyboard redesign (#36, now merged).

## Fixes

**1. Cursor disappeared intermittently while typing**
The tone-strip buttons used `onMouseDown` + `preventDefault` to stop a tap stealing focus from the textarea. On touch devices `mousedown` fires too late to prevent the focus shift, so tapping a tone blurred the field — and when `retoneLast` was a no-op (caret not after a vowel) it never refocused, leaving the caret gone. Switched to `onPointerDown` (covers mouse **and** touch); the textarea keeps focus and the caret stays put.

**2. Numbers mode showed two "ABC" keys**
`NUM_LAYOUT` had `{abc}` on both row 3 and row 4, so entering numbers mode rendered a duplicate ABC key where shift normally sits. Removed it from row 3 — the single ABC-return key now lives on row 4, consistent with every other layout's return key. Row 3 is now `. , ? ! ' ⌫`.

The mid tone key is unchanged (kept — it clears an applied accent in place); its aria label was clarified to "Mid tone (clear the mark)".

## Tests
- New: the tone strip exposes low/mid/high; the numbers layout has exactly one ABC-return key (on the bottom row).
- 55 passing, typecheck clean.

## Test plan
- [ ] Mobile `/keyboard`: type a vowel then a tone repeatedly — the caret never disappears, including when tapping a tone with the caret not after a vowel
- [ ] Tap `123` — exactly one `ABC` key (bottom-left); row 3 is `. , ? ! ' ⌫`
- [ ] Tone strip shows low/mid/high; mid clears an applied accent in place