### PR TITLE
Serve /sitemap.xml and /robots.txt from the frontend (SEO P0)

### DIFF
--- a/alarino_backend/src/alarino_backend/app.py
+++ b/alarino_backend/src/alarino_backend/app.py
@@ -13,6 +13,7 @@ from alarino_backend.runtime import _daily_word_cache, get_allowed_origins, logg
 from alarino_backend.translation_service import (
     bulk_upload_words,
     get_random_proverb,
+    get_sitemap_words,
     get_word_of_the_day,
     translate,
     translate_llm,
@@ -116,6 +117,13 @@ def admin_bulk_upload():
     dry_run = data.get("dry_run", True)
 
     response, status = bulk_upload_words(db, text_input, dry_run)
+    return jsonify(response), status
+
+
+@api_bp.route("/api/words", methods=["GET"])
+def list_sitemap_words():
+    logger.info("Sitemap words request received")
+    response, status = get_sitemap_words(db)
     return jsonify(response), status
 
 

--- a/alarino_backend/src/alarino_backend/response.py
+++ b/alarino_backend/src/alarino_backend/response.py
@@ -72,6 +72,14 @@ class BulkUploadResponseData(BaseResponseData):
     dry_run: bool
 
 
+@dataclass
+class SitemapWordsResponseData(BaseResponseData):
+    """The list of English word strings that have a Yoruba translation,
+    used by the frontend to build /sitemap.xml."""
+
+    words: List[str]
+
+
 class APIResponse:
     def __init__(self, success: bool, status: int, message: str, data: Optional[BaseResponseData] = None):
         self.success = success

--- a/alarino_backend/src/alarino_backend/translation_service.py
+++ b/alarino_backend/src/alarino_backend/translation_service.py
@@ -14,6 +14,7 @@ from alarino_backend.response import (
     BulkUploadResponseData,
     ProverbResponseData,
     SenseGroup,
+    SitemapWordsResponseData,
     TranslationInSenseGroup,
     TranslationResponseData,
     WordOfTheDayResponseData,
@@ -320,6 +321,31 @@ def get_random_proverb(db):
     except Exception as e:
         logger.error(f"Error fetching random proverb: {e}")
         return APIResponse.error("An error occurred while fetching a proverb.", 500).as_response()
+
+
+def get_sitemap_words(db) -> Tuple[Dict, int]:
+    """Return all English words that have at least one Yoruba translation.
+
+    Used by the frontend's /sitemap.xml route. Mirrors the query in
+    data/generate_sitemap.py, returning a sorted, de-duplicated list of the
+    normalized (lowercase, stripped) word strings.
+    """
+    try:
+        rows = (
+            db.session.query(Word.text)
+            .filter(Word.language == Language.ENGLISH.value)
+            .join(Translation, Word.w_id == Translation.source_word_id)
+            .distinct()
+            .all()
+        )
+        words = sorted(
+            {row[0].strip().lower() for row in rows if row[0] and row[0].strip()}
+        )
+        response_data = SitemapWordsResponseData(words=words)
+        return APIResponse.success("Sitemap words fetched successfully.", response_data).as_response()
+    except Exception as e:
+        logger.error(f"Error fetching sitemap words: {e}")
+        return APIResponse.error("An error occurred while fetching sitemap words.", 500).as_response()
 
 
 def _process_translation_pair(row: list, dry_run: bool, successful_pairs: list, failed_pairs: list):

--- a/alarino_backend/tests/test_app.py
+++ b/alarino_backend/tests/test_app.py
@@ -45,6 +45,7 @@ def test_expected_routes_are_registered(app):
         "/api/daily-word",
         "/api/proverb",
         "/api/admin/bulk-upload",
+        "/api/words",
         "/api/health",
     }.issubset(rules)
 
@@ -294,6 +295,28 @@ def test_admin_bulk_upload_returns_service_response(client, monkeypatch):
         "text_input": "apple,apulo",
         "dry_run": True,
     }
+
+
+def test_words_returns_service_response(client, monkeypatch):
+    payload = {
+        "success": True,
+        "status": 200,
+        "message": "Sitemap words fetched successfully.",
+        "data": {"words": ["abandon", "love"]},
+    }
+    captured = {}
+
+    def fake_get_sitemap_words(db_arg):
+        captured["db_arg"] = db_arg
+        return payload, 200
+
+    monkeypatch.setattr(app_module, "get_sitemap_words", fake_get_sitemap_words)
+
+    response = client.get("/api/words")
+
+    assert response.status_code == 200
+    assert response.get_json() == payload
+    assert captured == {"db_arg": db}
 
 
 def test_health_endpoint_contract(client):

--- a/alarino_backend/tests/test_translation_service.py
+++ b/alarino_backend/tests/test_translation_service.py
@@ -406,3 +406,39 @@ def test_translate_returns_404_when_no_curated_translation_in_either_direction(d
     )
     assert status == 404
     assert response["message"] == "Word found but translation not available."
+
+
+# ---- Sitemap word listing ----
+
+
+def test_get_sitemap_words_returns_only_translated_english_words(db_app):
+    # Two curated en→yo pairs, plus an English word with no translation
+    # (must be excluded) and a Yoruba-only word (must be excluded).
+    _seed_one_directional_pair("love", "ife")
+    _seed_one_directional_pair("water", "omi")
+    db.session.add(Word(language="en", text="lonely"))  # no translation
+    db.session.commit()
+
+    response, status = translation_service.get_sitemap_words(db)
+
+    assert status == 200
+    assert response["message"] == "Sitemap words fetched successfully."
+    assert response["data"]["words"] == ["love", "water"]
+
+
+def test_get_sitemap_words_dedupes_words_with_multiple_translations(db_app):
+    child = Word(language="en", text="child")
+    omo = Word(language="yo", text="ọmọ")
+    egbon = Word(language="yo", text="ẹgbọn")
+    db.session.add_all([child, omo, egbon])
+    db.session.flush()
+    from alarino_backend.data.seed_data_utils import create_translation
+
+    create_translation(child, omo)
+    create_translation(child, egbon)
+    db.session.commit()
+
+    response, status = translation_service.get_sitemap_words(db)
+
+    assert status == 200
+    assert response["data"]["words"] == ["child"]

--- a/frontend/app/robots.ts
+++ b/frontend/app/robots.ts
@@ -1,0 +1,17 @@
+import type { MetadataRoute } from "next";
+
+import { getFrontendSiteUrl } from "@/lib/env";
+
+const SITE_URL = getFrontendSiteUrl();
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: ["/admin", "/api/"]
+    },
+    sitemap: `${SITE_URL}/sitemap.xml`,
+    host: SITE_URL
+  };
+}

--- a/frontend/app/sitemap.ts
+++ b/frontend/app/sitemap.ts
@@ -4,10 +4,13 @@ import { getBackendInternalUrl, getFrontendSiteUrl } from "@/lib/env";
 
 const SITE_URL = getFrontendSiteUrl();
 
-// Regenerate the sitemap at most once a day so newly added words show up
-// without a redeploy. If the backend is unreachable (e.g. during the build)
-// we still emit the static routes below rather than failing.
-export const revalidate = 86400;
+// Render at request time, never at build. The frontend image runs
+// `next build` (frontend/Dockerfile) before the compose backend is
+// reachable, so a prerendered or ISR sitemap would bake in the
+// empty-backend fallback and keep serving a wordless sitemap until the
+// revalidate window elapsed — re-baked wordless on every deploy.
+// force-dynamic makes each request query the live backend instead.
+export const dynamic = "force-dynamic";
 
 const STATIC_ROUTES: MetadataRoute.Sitemap = [
   { url: `${SITE_URL}/`, changeFrequency: "daily", priority: 1 },
@@ -18,7 +21,7 @@ const STATIC_ROUTES: MetadataRoute.Sitemap = [
 async function fetchTranslatableWords(): Promise<string[]> {
   try {
     const res = await fetch(`${getBackendInternalUrl()}/api/words`, {
-      next: { revalidate }
+      cache: "no-store"
     });
     if (!res.ok) {
       return [];

--- a/frontend/app/sitemap.ts
+++ b/frontend/app/sitemap.ts
@@ -1,0 +1,43 @@
+import type { MetadataRoute } from "next";
+
+import { getBackendInternalUrl, getFrontendSiteUrl } from "@/lib/env";
+
+const SITE_URL = getFrontendSiteUrl();
+
+// Regenerate the sitemap at most once a day so newly added words show up
+// without a redeploy. If the backend is unreachable (e.g. during the build)
+// we still emit the static routes below rather than failing.
+export const revalidate = 86400;
+
+const STATIC_ROUTES: MetadataRoute.Sitemap = [
+  { url: `${SITE_URL}/`, changeFrequency: "daily", priority: 1 },
+  { url: `${SITE_URL}/keyboard`, changeFrequency: "monthly", priority: 0.6 },
+  { url: `${SITE_URL}/about`, changeFrequency: "monthly", priority: 0.4 }
+];
+
+async function fetchTranslatableWords(): Promise<string[]> {
+  try {
+    const res = await fetch(`${getBackendInternalUrl()}/api/words`, {
+      next: { revalidate }
+    });
+    if (!res.ok) {
+      return [];
+    }
+    const body = await res.json();
+    const words = body?.data?.words;
+    return Array.isArray(words) ? words : [];
+  } catch {
+    return [];
+  }
+}
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const words = await fetchTranslatableWords();
+  const wordRoutes: MetadataRoute.Sitemap = words.map((word) => ({
+    url: `${SITE_URL}/word/${encodeURIComponent(word)}`,
+    changeFrequency: "weekly",
+    priority: 0.8
+  }));
+
+  return [...STATIC_ROUTES, ...wordRoutes];
+}


### PR DESCRIPTION
## Why

Caddy proxies **all** traffic to the Next.js frontend (`reverse_proxy frontend:3000`), but the sitemap was generated by a cron script into the **backend** container's data dir — so it was never served. Verified live before this change:

- `https://alarino.com/sitemap.xml` → **404**
- `https://alarino.com/robots.txt` → **404**

Result: ~10,700 word pages had no sitemap reaching crawlers, and there was no robots guidance (e.g. `/admin` was crawlable, no `Sitemap:` pointer). This is the highest-leverage SEO fix — without a served sitemap Google discovers those pages only via internal links, slowly.

## What

Dynamic Next.js metadata routes that serve fresh data, replacing the orphaned static file:

- **Backend** — new `GET /api/words` returning every English word that has a Yoruba translation. Logic mirrors `data/generate_sitemap.py` (`get_sitemap_words()` service fn + `SitemapWordsResponseData`).
- **`frontend/app/sitemap.ts`** — `force-dynamic`, fetches `/api/words` server-side per request (`cache: "no-store"`) and emits the homepage, `/keyboard`, `/about`, and every `/word/<w>` URL. Renders against the live backend at request time and falls back to just the static routes if the backend is momentarily unreachable (without caching that fallback).
- **`frontend/app/robots.ts`** — `allow: /`, `disallow: /admin, /api/`, and `Sitemap: https://alarino.com/sitemap.xml`.

### Why the route is dynamic (not ISR)

The frontend image runs `next build` (frontend/Dockerfile) **before** the compose backend is reachable. An ISR sitemap (`revalidate`) would prerender the empty-backend fallback at build time, and ISR treats that build-time entry as fresh — so it would serve a **wordless** sitemap for up to the revalidate window and re-bake it wordless on every deploy. `force-dynamic` renders per request instead, so the word URLs are always present in production.

## Verification

- Backend: 41 app/service tests pass, including a real-DB test of `get_sitemap_words` (excludes untranslated/Yoruba-only words, dedupes multi-translation words) and an endpoint delegation test.
- Frontend: `tsc --noEmit` clean, eslint clean, `next build` succeeds — `/robots.txt` registers static, `/sitemap.xml` as `ƒ` Dynamic.
- End-to-end: `next build` (backend down) then `next start` against a seeded backend → `/sitemap.xml` serves the `/word/...` URLs fetched at runtime; `/robots.txt` correct.

## Follow-ups (not in this PR)

- The old `alarino_backend/.../data/generate_sitemap.py` + static `sitemap.xml` and its cron are now superseded by this route. Safe to retire in a cleanup PR (left in place here to avoid touching deployment cron in an SEO change).
- Remaining SEO P1s discussed: Open Graph / Twitter cards, per-word OG images, JSON-LD (`WebSite`/`SearchAction`, `DefinedTerm`).